### PR TITLE
Updates to support non-AD LDAP systems

### DIFF
--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
@@ -255,12 +255,13 @@ namespace ldapcp.ControlTemplates
             this.ValidateLdapConnection();
         }
 
-        private TableCell GetTableCell(string Value)
-        {
-            TableCell tc = new TableCell();
-            tc.Text = Value;
-            return tc;
-        }
+		// FORTIFY WARNING
+        //private TableCell GetTableCell(string Value)
+        //{
+        //    TableCell tc = new TableCell();
+        //    tc.Text = Value;
+        //    return tc;
+        //}
 
         protected void BtnAddLdapConnection_Click(object sender, EventArgs e)
         {

--- a/LDAPCP/LDAPCP.cs
+++ b/LDAPCP/LDAPCP.cs
@@ -197,8 +197,7 @@ namespace ldapcp
                         this.CurrentConfiguration.LDAPConnectionsProp.Add(currentCoco.CopyPersistedProperties());
                     }
 
-                    // FORTIFY WARNING: removed since this code path didn't seem to be used
-                    //SetCustomConfiguration(context, entityTypes);
+                    SetCustomConfiguration(context, entityTypes);
                     if (this.CurrentConfiguration.AttributesListProp == null)
                     {
                         // this.CurrentConfiguration.AttributesListProp was set to null in SetCustomConfiguration, which is bad


### PR DESCRIPTION
Had a few issues with non-AD LDAP systems.  Added support for case insensitive matching for LDAP properties as some LDAP systems might have propertyName, PropertyName, or propertyname set in any particular entity (as the casing is not required to be consistent).  Also changed the usage of UserPrincipal FindByIdentity in AugmentWithGroups to use a DirectorySearcher since AD may not be the group membership LDAP being used.