### PR TITLE
New release 2017-06

### DIFF
--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx
@@ -23,25 +23,22 @@
         IsDefaultADConnectionCreated = <%= ViewState["IsDefaultADConnectionCreated"].ToString().ToLower() %>;
         ForceCheckCustomLdapConnection = <%= ViewState["ForceCheckCustomLdapConnection"].ToString().ToLower() %>;
 			
-        if (IsDefaultADConnectionCreated)
-        {
+        if (IsDefaultADConnectionCreated) {
             // Disable radio button to create default connection and select other one.
             $('#<%= RbUseServerDomain.ClientID %>').prop('disabled', true);
             $('#<%= RbUseCustomConnection.ClientID %>').prop('checked', true);
             // Needed to trigger the click to display the button that tests connection
             $('#<%= RbUseCustomConnection.ClientID %>').trigger('click');
         }
-        else
-        {
+        else {
             // No default connection, give possibility to create one.
             $('#<%= RbUseServerDomain.ClientID %>').prop('enabled', true);
             $('#<%= RbUseServerDomain.ClientID %>').prop('checked', true);
             // Hide asterisk in custom LDAP connection fields
             $('#divNewLdapConnection').find('em').hide();
         }
-			
-        if (ForceCheckCustomLdapConnection)
-        {
+
+        if (ForceCheckCustomLdapConnection) {
             $('#<%= RbUseCustomConnection.ClientID %>').prop('checked', true);
             // Needed to trigger the click to display the button that tests connection
             $('#<%= RbUseCustomConnection.ClientID %>').trigger('click');
@@ -53,13 +50,13 @@
         var enableAugmentationControls = $('#<%= ChkEnableAugmentation.ClientID %>').is(":checked");
         if (enableAugmentationControls) {
             $("#AugmentationControls").children().prop('disabled', false);
-			$("#AugmentationControlsGrid").children().removeAttr('disabled');
-			$("#AugmentationControlsGrid").children().prop('disabled', null);
+            $("#AugmentationControlsGrid").children().removeAttr('disabled');
+            $("#AugmentationControlsGrid").children().prop('disabled', null);
         }
         else {
             $("#AugmentationControls").children().prop('disabled', true);
-			$("#AugmentationControlsGrid").children().attr('disabled', '');
-			$("#AugmentationControlsGrid").children().prop('disabled');
+            $("#AugmentationControlsGrid").children().attr('disabled', '');
+            $("#AugmentationControlsGrid").children().prop('disabled');
         }
     }
 
@@ -72,7 +69,7 @@
         $('#<%= BtnTestLdapConnection.ClientID %>').show('fast');
         $('#divNewLdapConnection').find('em').show();
     }
-		
+
     window.Ldapcp.AdminGlobalSettingsControl.CheckDefaultADConnection = function () {
         $('#divNewLdapConnection').find('em').hide();
         $('#<%= BtnTestLdapConnection.ClientID %>').hide('fast');
@@ -88,72 +85,73 @@
 </script>
 
 <style>
-	/* Maximaze space available for description text */
-	.ms-inputformdescription {
-		width: 100%;
-	}
+    /* Maximaze space available for description text */
+    .ms-inputformdescription {
+        width: 100%;
+    }
 
-	/* corev15.css set it to 0.9em, which makes it too small */
-	.ms-descriptiontext {
-		font-size: 1em;
-	}
-	/* Set the size of the right part with all input controls */
-	.ms-inputformcontrols {
-		width: 650px;
-	}
+    /* corev15.css set it to 0.9em, which makes it too small */
+    .ms-descriptiontext {
+        font-size: 1em;
+    }
+    /* Set the size of the right part with all input controls */
+    .ms-inputformcontrols {
+        width: 650px;
+    }
 
-	/* Set the display of the title of each section */
-	.ms-standardheader {
-		color: #0072c6;
-		font-weight: bold;
-		font-size: 1.15em;
-	}
+    /* Set the display of the title of each section */
+    .ms-standardheader {
+        color: #0072c6;
+        font-weight: bold;
+        font-size: 1.15em;
+    }
 
-	/* Only used in td elements in grid view that displays LDAP connections */
-	.ms-vb2 {
-		vertical-align: middle;
-	}
+    /* Only used in td elements in grid view that displays LDAP connections */
+    .ms-vb2 {
+        vertical-align: middle;
+    }
 
-	.ldapcp-success {
-		color: green;
-		font-weight: bold;
-	}
+    .ldapcp-success {
+        color: green;
+        font-weight: bold;
+    }
 
-	.ldapcp-HideCol {
-		display: none;
-	}
+    .ldapcp-HideCol {
+        display: none;
+    }
 
-	#divNewLdapConnection label {
-		display: inline-block;
-		line-height: 1.8;
-		width: 100px;
-	}
+    #divNewLdapConnection label {
+        display: inline-block;
+        line-height: 1.8;
+        width: 100px;
+    }
 
-	#divNewLdapConnection fieldset {
-		border: 0;
-		margin: 0;
-		padding: 0;
-	}
+    #divNewLdapConnection fieldset {
+        border: 0;
+        margin: 0;
+        padding: 0;
+    }
 
-		#divNewLdapConnection fieldset ol {
-			margin: 0;
-			padding: 0;
-		}
+        #divNewLdapConnection fieldset ol {
+            margin: 0;
+            padding: 0;
+        }
 
-		#divNewLdapConnection fieldset li {
-			list-style: none;
-			padding: 5px;
-			margin: 0;
-		}
+        #divNewLdapConnection fieldset li {
+            list-style: none;
+            padding: 5px;
+            margin: 0;
+        }
 
-	#divNewLdapConnection em {
-		font-weight: bold;
-		font-style: normal;
-		color: #f00;
-	}
+    #divNewLdapConnection em {
+        font-weight: bold;
+        font-style: normal;
+        color: #f00;
+    }
 </style>
 
-<p class="ms-error"><asp:Label ID="LabelErrorMessage" runat="server" EnableViewState="False" /></p>
+<p class="ms-error">
+    <asp:Label ID="LabelErrorMessage" runat="server" EnableViewState="False" /></p>
 
 <wssuc:ButtonSection ID="ValidateTopSection" runat="server">
     <template_buttons>
@@ -242,7 +240,7 @@
 	</template_inputformcontrols>
 </wssuc:InputFormSection>
 
-<wssuc:inputformsection ID="AugmentationSection" runat="server" Visible="<%# ShowAugmentationSection %>" title="Augmentation" description="Configure augmentation to append groups of which users are members during logon.<br/><br/><b>Important:</b> at the time of the augmentation LDAPCP has very little information about the user: it only knows his identity claim.<br/>For this reason it's highly recommended to use an identity claim with a value guaranteed to be unique between all LDAP servers, like the email or the UPN.">
+<wssuc:inputformsection ID="AugmentationSection" runat="server" Visible="<%# ShowAugmentationSection %>" title="Augmentation" description="Enable augmentation to let LDAPCP get group membership of federated users.<br/><br/><b>Important:</b> During augmentation LDAPCP only knows the identity claim of the user, so it is strongly recommended to use an identity claim that ensures the uniqueness of the value across all domains, such as the email or the UPN.">
     <template_inputformcontrols>
         <p class="ms-error"><asp:Label ID="Label1" runat="server" EnableViewState="False" /></p>
         <asp:Checkbox Checked="false" Runat="server" Name="ChkEnableAugmentation" ID="ChkEnableAugmentation" OnClick="window.Ldapcp.AdminGlobalSettingsControl.InitAugmentationControls();" Text="Enable augmentation" />
@@ -253,18 +251,20 @@
                 <asp:ListItem Selected="True" Value="None"></asp:ListItem>
             </asp:DropDownList>
 			<tr><td>
-			<wssawc:EncodedLiteral runat="server" text="Select which LDAP path to query for augmentation:" EncodeMethod='HtmlEncodeAllowSimpleTextFormatting'/>
-            <br />
+			<wssawc:EncodedLiteral runat="server" text="<p>For Active Directory servers, the preferred way to get groups is using <a href='https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.userprincipal.getauthorizationgroups.aspx' target='_blank'>UserPrincipal.GetAuthorizationGroups()</a>.<br />Otherwise LDAPCP reads LDAP attribute memberOf/uniquememberof of the user.</p>" EncodeMethod='NoEncode'/>
 			<div id="AugmentationControlsGrid">
             <wssawc:SPGridView ID="GridLdapConnections" runat="server" AutoGenerateColumns="False" ShowHeader="false">
                 <Columns>
-                    <asp:TemplateField ItemStyle-Width="10">
+                    <asp:TemplateField>
                         <ItemTemplate>
-                            <asp:CheckBox ID="ChkAugmentationEnableOnCoco" runat="server" Checked='<%# Bind("AugmentationEnabledProp") %>' />
-							<asp:TextBox ID="IdPropHidden" runat="server" Text='<%# Bind("IdProp") %>' Visible="false" />
+							<fieldset>
+                            <asp:TextBox ID="IdPropHidden" runat="server" Text='<%# Bind("IdProp") %>' Visible="false" />
+							<legend><span>LDAP Server "<asp:Label ID="TextPath" runat="server" Text='<%# Bind("PathProp") %>' />":</span></legend>
+                            <asp:CheckBox ID="ChkAugmentationEnableOnCoco" runat="server" Checked='<%# Bind("AugmentationEnabledProp") %>' Text="Query this server" />
+                            <asp:CheckBox ID="ChkGetGroupMembershipAsADDomain" runat="server" Checked='<%# Bind("GetGroupMembershipAsADDomainProp") %>' Text="This is an Active Directory server, get groups using <a href='https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.userprincipal.getauthorizationgroups.aspx' target='_blank'>UserPrincipal.GetAuthorizationGroups</a>" />
+							</fieldset>
                         </ItemTemplate>
                     </asp:TemplateField>
-                    <asp:BoundField DataField="PathProp" HeaderText="" />
                 </Columns>
             </wssawc:SPGridView>
 			</div>

--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx
@@ -179,7 +179,7 @@
 
 <wssuc:InputFormSection ID="NewLdapConnectionSection" Title="New LDAP connection" runat="server" Visible="<%# ShowNewLdapConnectionSection %>">
     <template_description>
-		<wssawc:EncodedLiteral runat="server" text="Create a new LDAP connection. A connection to same AD as SharePoint servers is created by default." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting'/>
+		<wssawc:EncodedLiteral runat="server" text="Create a new LDAP connection. By default, LDAPCP adds a connection to the Active Directory domain of SharePoint servers, labelled 'Connect to SharePoint domain'." EncodeMethod='HtmlEncodeAllowSimpleTextFormatting'/>
 	</template_description>
     <template_inputformcontrols>
 		<tr><td>
@@ -190,7 +190,7 @@
 			GroupName="RbLDAPConnection"
 			CausesValidation="false"
 			runat="server"
-			onclick="window.Ldapcp.LdapcpSettingsPage.CheckDefaultADConnection()"					>
+			onclick="window.Ldapcp.LdapcpSettingsPage.CheckDefaultADConnection()">
 			<wssawc:EncodedLiteral runat="server" text="Connect to same AD as SharePoint servers, with application pool credentials." EncodeMethod='HtmlEncode'/>
 		</wssawc:InputFormRadioButton>
 		<wssawc:InputFormRadioButton id="RbUseCustomConnection"
@@ -261,7 +261,7 @@
                             <asp:TextBox ID="IdPropHidden" runat="server" Text='<%# Bind("IdProp") %>' Visible="false" />
 							<legend><span>LDAP Server "<asp:Label ID="TextPath" runat="server" Text='<%# Bind("PathProp") %>' />":</span></legend>
                             <asp:CheckBox ID="ChkAugmentationEnableOnCoco" runat="server" Checked='<%# Bind("AugmentationEnabledProp") %>' Text="Query this server" />
-                            <asp:CheckBox ID="ChkGetGroupMembershipAsADDomain" runat="server" Checked='<%# Bind("GetGroupMembershipAsADDomainProp") %>' Text="This is an Active Directory server, get groups using <a href='https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.userprincipal.getauthorizationgroups.aspx' target='_blank'>UserPrincipal.GetAuthorizationGroups</a>" />
+                            <asp:CheckBox ID="ChkGetGroupMembershipAsADDomain" runat="server" Checked='<%# Bind("GetGroupMembershipAsADDomainProp") %>' Text="This is an Active Directory server, use <a href='https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.userprincipal.getauthorizationgroups.aspx' target='_blank'>UserPrincipal.GetAuthorizationGroups</a>" />
 							</fieldset>
                         </ItemTemplate>
                     </asp:TemplateField>

--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
@@ -255,12 +255,13 @@ namespace ldapcp.ControlTemplates
             this.ValidateLdapConnection();
         }
 
-        private TableCell GetTableCell(string Value)
-        {
-            TableCell tc = new TableCell();
-            tc.Text = Value;
-            return tc;
-        }
+		// FORTIFY WARNING
+        //private TableCell GetTableCell(string Value)
+        //{
+        //    TableCell tc = new TableCell();
+        //    tc.Text = Value;
+        //    return tc;
+        //}
 
         protected void BtnAddLdapConnection_Click(object sender, EventArgs e)
         {

--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
@@ -204,9 +204,12 @@ namespace ldapcp.ControlTemplates
             foreach (GridViewRow item in GridLdapConnections.Rows)
             {
                 CheckBox chkAugEn = (CheckBox)item.FindControl("ChkAugmentationEnableOnCoco");
+                CheckBox chkIsADDomain = (CheckBox)item.FindControl("ChkGetGroupMembershipAsADDomain");
                 TextBox txtId = (TextBox)item.FindControl("IdPropHidden");
 
-                PersistedObject.LDAPConnectionsProp.First(x => x.Id == new Guid(txtId.Text)).AugmentationEnabled = chkAugEn.Checked;
+                var coco = PersistedObject.LDAPConnectionsProp.First(x => x.IdProp == new Guid(txtId.Text));
+                coco.AugmentationEnabledProp = chkAugEn.Checked;
+                coco.GetGroupMembershipAsADDomainProp = chkIsADDomain.Checked;
             }
         }
 
@@ -254,14 +257,6 @@ namespace ldapcp.ControlTemplates
         {
             this.ValidateLdapConnection();
         }
-
-		// FORTIFY WARNING
-        //private TableCell GetTableCell(string Value)
-        //{
-        //    TableCell tc = new TableCell();
-        //    tc.Text = Value;
-        //    return tc;
-        //}
 
         protected void BtnAddLdapConnection_Click(object sender, EventArgs e)
         {

--- a/LDAPCP/ADMIN/LDAPCP/LdapcpSettings.aspx
+++ b/LDAPCP/ADMIN/LDAPCP/LdapcpSettings.aspx
@@ -8,7 +8,7 @@
 <asp:Content ID="PageHead" ContentPlaceHolderID="PlaceHolderAdditionalPageHead" runat="server" />
 <asp:Content ID="PageTitle" ContentPlaceHolderID="PlaceHolderPageTitle" runat="server">LDAPCP Configuration</asp:Content>
 <asp:Content ID="PageTitleInTitleArea" ContentPlaceHolderID="PlaceHolderPageTitleInTitleArea" runat="server">
-<%= String.Format("LDAPCP v{0} - <a href=\"https://ldapcp.codeplex.com\" target=\"_blank\">ldapcp.codeplex.com</a>", FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(LDAPCP)).Location).FileVersion) %>
+<%= String.Format("LDAPCP v{0} - <a href=\"https://github.com/Yvand/LDAPCP\" target=\"_blank\">GitHub.com/Yvand/LDAPCP</a>", FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(LDAPCP)).Location).FileVersion) %>
 </asp:Content>
 <asp:Content ID="Main" ContentPlaceHolderID="PlaceHolderMain" runat="server">
     <table border="0" cellspacing="0" cellpadding="0" width="100%">

--- a/LDAPCP/LDAPCP.cs
+++ b/LDAPCP/LDAPCP.cs
@@ -1109,8 +1109,7 @@ namespace ldapcp
                     }
 
                     List<SPClaim> groups = new List<SPClaim>();
-                    string claimType = groupAttribute.ClaimType;
-                    object lockResults = new object(); ;
+                    object lockResults = new object();
                     Stopwatch stopWatch = new Stopwatch();
                     stopWatch.Start();
                     Parallel.ForEach(connections, coco =>

--- a/LDAPCP/LDAPCP.cs
+++ b/LDAPCP/LDAPCP.cs
@@ -756,13 +756,18 @@ namespace ldapcp
                 foreach (var attr in attributes)
                 {
                     // Check if current attribute object class matches the current LDAP result
-                    if (!resultPropertyCollection[LDAPObjectClassName].Contains(attr.LDAPObjectClassProp)) continue;
+					// Changed to a case insensitive search of the ldap properties
+                    if (!resultPropertyCollection[LDAPObjectClassName].Cast<string>().Contains(attr.LDAPObjectClassProp, StringComparer.InvariantCultureIgnoreCase)) continue;
 
+					// Added to use for case insensitive search of ldap properties
+                    var resultPropertyCollectionPropertyNames = resultPropertyCollection.PropertyNames.Cast<string>();
                     // Check if current LDAP result contains LDAP attribute of current attribute
-                    if (!resultPropertyCollection.Contains(attr.LDAPAttribute)) continue;
+					// Changed to a case insensitve search
+                    if (!resultPropertyCollectionPropertyNames.Contains(attr.LDAPAttribute, StringComparer.InvariantCultureIgnoreCase)) continue;
 
                     // TODO: investigate http://ldapcp.codeplex.com/discussions/648655
-                    string value = resultPropertyCollection[attr.LDAPAttribute][0].ToString();
+					// Changed to a case insensitve search of properties
+                    string value = resultPropertyCollection[resultPropertyCollectionPropertyNames.Where(x => x.ToLowerInvariant() == attr.LDAPAttribute.ToLowerInvariant()).First()][0].ToString();
                     // Check if current attribute matches the input
                     if (requestInfo.ExactSearch)
                     {
@@ -772,7 +777,8 @@ namespace ldapcp
                     {
                         if (this.CurrentConfiguration.AddWildcardInFrontOfQueryProp)
                         {
-                            if (!value.Contains(requestInfo.Input)) continue;
+							// Changed to a case insensitive search
+                            if (value.IndexOf(requestInfo.Input, StringComparison.InvariantCultureIgnoreCase) != -1) continue;
                         }
                         else
                         {
@@ -784,7 +790,8 @@ namespace ldapcp
                     AttributeHelper objCompare;
                     if (attr.CreateAsIdentityClaim && (String.Equals(attr.LDAPObjectClassProp, IdentityAttribute.LDAPObjectClassProp, StringComparison.InvariantCultureIgnoreCase)))
                     {
-                        if (!resultPropertyCollection.Contains(IdentityAttribute.LDAPAttribute)) continue;
+						// Changed to a case insensitive search
+                        if (!resultPropertyCollectionPropertyNames.Contains(attr.LDAPAttribute, StringComparer.InvariantCultureIgnoreCase)) continue;
                         // If exactSearch is true, then IdentityAttribute.LDAPAttribute value should be also equals to input, otherwise igno
                         objCompare = IdentityAttribute;
                     }
@@ -886,59 +893,62 @@ namespace ldapcp
                     return;
                 }
                 DirectoryEntry directory = LDAPServer.Directory;
-                DirectorySearcher ds = new DirectorySearcher(LDAPServer.Filter);
-                ds.SearchRoot = directory;
-                ds.ClientTimeout = new TimeSpan(0, 0, this.CurrentConfiguration.TimeoutProp); // Set the timeout of the query
-                ds.PropertiesToLoad.Add(LDAPObjectClassName);
-                ds.PropertiesToLoad.Add("nETBIOSName");
-                foreach (var ldapAttribute in ProcessedAttributes.Where(x => !String.IsNullOrEmpty(x.LDAPAttribute)))
+                using (DirectorySearcher ds = new DirectorySearcher(LDAPServer.Filter))
                 {
-                    ds.PropertiesToLoad.Add(ldapAttribute.LDAPAttribute);
-                    if (!String.IsNullOrEmpty(ldapAttribute.LDAPAttributeToDisplayProp)) ds.PropertiesToLoad.Add(ldapAttribute.LDAPAttributeToDisplayProp);
-                }
-                // Populate additional attributes that are not part of the filter but are requested in the result
-                foreach (var metadataAttribute in MetadataAttributes)
-                {
-                    if (!ds.PropertiesToLoad.Contains(metadataAttribute.LDAPAttribute)) ds.PropertiesToLoad.Add(metadataAttribute.LDAPAttribute);
-                }
-
-                using (new SPMonitoredScope(String.Format("[{0}] Connecting to \"{1}\" with AuthenticationType \"{2}\" and filter \"{3}\"", ProviderInternalName, directory.Path, directory.AuthenticationType.ToString(), ds.Filter), 3000)) // threshold of 3 seconds before it's considered too much. If exceeded it is recorded in a higher logging level
-                {
-                    try
+                    ds.SearchRoot = directory;
+                    ds.ClientTimeout = new TimeSpan(0, 0, this.CurrentConfiguration.TimeoutProp); // Set the timeout of the query
+                    ds.PropertiesToLoad.Add(LDAPObjectClassName);
+                    ds.PropertiesToLoad.Add("nETBIOSName");
+                    foreach (var ldapAttribute in ProcessedAttributes.Where(x => !String.IsNullOrEmpty(x.LDAPAttribute)))
                     {
-                        LdapcpLogging.Log(String.Format("[{0}] Connecting to \"{1}\" with AuthenticationType \"{2}\" and filter \"{3}\"", ProviderInternalName, directory.Path, directory.AuthenticationType.ToString(), ds.Filter), TraceSeverity.Medium, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
-                        // Send LDAP query to server
-                        using (SearchResultCollection directoryResults = ds.FindAll())
+                        ds.PropertiesToLoad.Add(ldapAttribute.LDAPAttribute);
+                        if (!String.IsNullOrEmpty(ldapAttribute.LDAPAttributeToDisplayProp)) ds.PropertiesToLoad.Add(ldapAttribute.LDAPAttributeToDisplayProp);
+                    }
+                    // Populate additional attributes that are not part of the filter but are requested in the result
+                    foreach (var metadataAttribute in MetadataAttributes)
+                    {
+                        if (!ds.PropertiesToLoad.Contains(metadataAttribute.LDAPAttribute)) ds.PropertiesToLoad.Add(metadataAttribute.LDAPAttribute);
+                    }
+
+					// FORTIFY WARNING: added a using statement
+                    using (new SPMonitoredScope(String.Format("[{0}] Connecting to \"{1}\" with AuthenticationType \"{2}\" and filter \"{3}\"", ProviderInternalName, directory.Path, directory.AuthenticationType.ToString(), ds.Filter), 3000)) // threshold of 3 seconds before it's considered too much. If exceeded it is recorded in a higher logging level
+                    {
+                        try
                         {
-                            LdapcpLogging.Log(String.Format("[{0}] \"{1}\" returned {2} result(s)", ProviderInternalName, directory.Path, directoryResults.Count.ToString()), TraceSeverity.Medium, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
-                            if (directoryResults != null && directoryResults.Count > 0)
+                            LdapcpLogging.Log(String.Format("[{0}] Connecting to \"{1}\" with AuthenticationType \"{2}\" and filter \"{3}\"", ProviderInternalName, directory.Path, directory.AuthenticationType.ToString(), ds.Filter), TraceSeverity.Medium, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
+                            // Send LDAP query to server
+                            using (SearchResultCollection directoryResults = ds.FindAll())
                             {
-                                lock (lockResults)
+                                LdapcpLogging.Log(String.Format("[{0}] \"{1}\" returned {2} result(s)", ProviderInternalName, directory.Path, directoryResults.Count.ToString()), TraceSeverity.Medium, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
+                                if (directoryResults != null && directoryResults.Count > 0)
                                 {
-                                    // Retrieve FQDN and domain name of current DirectoryEntry
-                                    string domainName, domainFQDN = String.Empty;
-                                    RequestInformation.GetDomainInformation(directory, out domainName, out domainFQDN);
-                                    foreach (SearchResult item in directoryResults)
+                                    lock (lockResults)
                                     {
-                                        results.Add(new LDAPSearchResultWrapper()
+                                        // Retrieve FQDN and domain name of current DirectoryEntry
+                                        string domainName, domainFQDN = String.Empty;
+                                        RequestInformation.GetDomainInformation(directory, out domainName, out domainFQDN);
+                                        foreach (SearchResult item in directoryResults)
                                         {
-                                            SearchResult = item,
-                                            DomainName = domainName,
-                                            DomainFQDN = domainFQDN,
-                                        });
+                                            results.Add(new LDAPSearchResultWrapper()
+                                            {
+                                                SearchResult = item,
+                                                DomainName = domainName,
+                                                DomainFQDN = domainFQDN,
+                                            });
+                                        }
                                     }
+                                    LdapcpLogging.Log(String.Format("[{0}] Got {1} result(s) from {2}", ProviderInternalName, directoryResults.Count.ToString(), directory.Path), TraceSeverity.Verbose, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
                                 }
-                                LdapcpLogging.Log(String.Format("[{0}] Got {1} result(s) from {2}", ProviderInternalName, directoryResults.Count.ToString(), directory.Path), TraceSeverity.Verbose, EventSeverity.Information, LdapcpLogging.Categories.LDAP_Lookup);
                             }
                         }
-                    }
-                    catch (Exception ex)
-                    {
-                        LdapcpLogging.LogException(ProviderInternalName, "during connection to LDAP server " + directory.Path, LdapcpLogging.Categories.LDAP_Lookup, ex);
-                    }
-                    finally
-                    {
-                        directory.Dispose();
+                        catch (Exception ex)
+                        {
+                            LdapcpLogging.LogException(ProviderInternalName, "during connection to LDAP server " + directory.Path, LdapcpLogging.Categories.LDAP_Lookup, ex);
+                        }
+                        finally
+                        {
+                            directory.Dispose();
+                        }
                     }
                 }
             });
@@ -1151,8 +1161,59 @@ namespace ldapcp
                     {
                         string directoryDomainName, directoryDomainFqdn;
                         RequestInformation.GetDomainInformation(directory, out directoryDomainName, out directoryDomainFqdn);
+
+                        // Changed to support a non-AD LDAP
+                        using (DirectorySearcher searcher = new DirectorySearcher(directory))
+                        {
+                            searcher.Filter = string.Format("(&(ObjectClass={0})({1}={2}){3})", IdentityAttribute.LDAPObjectClassProp, IdentityAttribute.LDAPAttribute, requestInfo.IncomingEntity.Value, IdentityAttribute.AdditionalLDAPFilterProp);
+                            searcher.PropertiesToLoad.Add("memberOf");
+                            searcher.PropertiesToLoad.Add("uniquememberof");
+
+                            SearchResult result = searcher.FindOne();
+                            int propertyCount = result.Properties["memberOf"].Count;
+                            var groupCollection = result.Properties["memberOf"];
+
+                            if (propertyCount == 0)
+                            {
+                                propertyCount = result.Properties["uniquememberof"].Count;
+                                groupCollection = result.Properties["uniquememberof"];
+                            }
+
+                            string groupDN;
+                            int equalsIndex, commaIndex;
+
+                            for (int propertyCounter = 0; propertyCounter < propertyCount; propertyCounter++)
+                            {
+                                groupDN = (string)groupCollection[propertyCounter];
+
+                                equalsIndex = groupDN.IndexOf("=", 1);
+                                commaIndex = groupDN.IndexOf(",", 1);
+
+                                if (equalsIndex != -1 && commaIndex != -1)
+                                {
+                                    groupDN = groupDN.Substring(equalsIndex + 1, commaIndex - equalsIndex - 1);
+                                    string groupDomainName, groupDomainFqdn;
+                                    RequestInformation.GetDomainInformation(groupDN, out groupDomainName, out groupDomainFqdn);
+                                    string claimValue = groupDN;
+                                    if (!String.IsNullOrEmpty(groupAttribute.PrefixToAddToValueReturnedProp) && groupAttribute.PrefixToAddToValueReturnedProp.Contains(Constants.LDAPCPCONFIG_TOKENDOMAINNAME))
+                                        claimValue = groupAttribute.PrefixToAddToValueReturnedProp.Replace(Constants.LDAPCPCONFIG_TOKENDOMAINNAME, groupDomainName) + groupDN;
+                                    else if (!String.IsNullOrEmpty(groupAttribute.PrefixToAddToValueReturnedProp) && groupAttribute.PrefixToAddToValueReturnedProp.Contains(Constants.LDAPCPCONFIG_TOKENDOMAINFQDN))
+                                        claimValue = groupAttribute.PrefixToAddToValueReturnedProp.Replace(Constants.LDAPCPCONFIG_TOKENDOMAINFQDN, groupDomainFqdn) + groupDN;
+                                    SPClaim claim = CreateClaim(groupAttribute.ClaimType, claimValue, groupAttribute.ClaimValueType, false);
+                                    groups.Add(claim);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex) 
+                    {
+                        LdapcpLogging.LogException(ProviderInternalName, String.Format("while getting group membership of user {0} in {1}. This is likely due to a bug in .NET framework in UserPrincipal.GetAuthorizationGroups (as of v4.6.1), especially if user is member (directly or not) of a group either in a child domain that was migrated, or a group that has special (deny) permissions.", requestInfo.IncomingEntity.Value, directory.Path), LdapcpLogging.Categories.Augmentation, ex);
+                    }
+
+                        /*
                         PrincipalContext principalContext = new PrincipalContext(ContextType.Domain, directoryDomainFqdn);
                         UserPrincipal adUser = UserPrincipal.FindByIdentity(principalContext, requestInfo.IncomingEntity.Value);
+
                         if (adUser == null) return;
                         lock (lockResults)
                         {
@@ -1182,6 +1243,7 @@ namespace ldapcp
                         LdapcpLogging.LogException(ProviderInternalName, String.Format("while getting group membership of user {0} in {1}", requestInfo.IncomingEntity.Value, directory.Path), LdapcpLogging.Categories.Augmentation, ex);
                     }
                     finally { }
+                         */
                 }
             });
             stopWatch.Stop();

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -537,7 +537,7 @@ namespace ldapcp
     public class LDAPConnection : SPAutoSerializingObject
     {
         [Persisted]
-        public Guid Id = Guid.NewGuid();
+        internal Guid Id = Guid.NewGuid();
         public Guid IdProp
         {
             get { return Id; }
@@ -545,7 +545,7 @@ namespace ldapcp
         }
 
         [Persisted]
-        public string Path;
+        internal string Path;
         public string PathProp
         {
             get { return Path; }
@@ -553,24 +553,27 @@ namespace ldapcp
         }
 
         [Persisted]
-        public string Username;
+        internal string Username;
 
         [Persisted]
-        public string Password;
+        internal string Password;
 
         [Persisted]
-        public string Metadata;
+        internal string Metadata;
 
         /// <summary>
         /// Specifies the types of authentication
         /// http://msdn.microsoft.com/en-us/library/system.directoryservices.authenticationtypes(v=vs.110).aspx
         /// </summary>
         [Persisted]
-        public AuthenticationTypes AuthenticationTypes;
+        internal AuthenticationTypes AuthenticationTypes;
 
         [Persisted]
-        public bool UserServerDirectoryEntry;
+        internal bool UserServerDirectoryEntry;
 
+        /// <summary>
+        /// If true: this server will be queried to perform augmentation
+        /// </summary>
         [Persisted]
         public bool AugmentationEnabled;
         public bool AugmentationEnabledProp
@@ -578,6 +581,24 @@ namespace ldapcp
             get { return AugmentationEnabled; }
             set { AugmentationEnabled = value; }
         }
+
+
+        /// <summary>
+        /// If true: get group membership with UserPrincipal.GetAuthorizationGroups()
+        /// If false: get group membership with LDAP queries
+        /// </summary>
+        [Persisted]
+        public bool GetGroupMembershipAsADDomain = true;
+        public bool GetGroupMembershipAsADDomainProp
+        {
+            get { return GetGroupMembershipAsADDomain; }
+            set { GetGroupMembershipAsADDomain = value; }
+        }
+
+        /// <summary>
+        /// DirectoryEntry used to make LDAP queries
+        /// </summary>
+        public DirectoryEntry directoryEntry;
 
         public LDAPConnection()
         {
@@ -595,9 +616,11 @@ namespace ldapcp
                 AuthenticationTypes = this.AuthenticationTypes,
                 UserServerDirectoryEntry = this.UserServerDirectoryEntry,
                 AugmentationEnabled = this.AugmentationEnabled,
+                GetGroupMembershipAsADDomain = this.GetGroupMembershipAsADDomain,
             };
             return copy;
         }
+
     }
 
     /// <summary>
@@ -747,6 +770,11 @@ namespace ldapcp
             return Regex.Replace(fullAccountName, RegexAccountFromFullAccountName, "$1", RegexOptions.None);
         }
 
+        /// <summary>
+        /// Returns the string before the '\'
+        /// </summary>
+        /// <param name="fullAccountName">e.g. "mylds.local\ldsgroup1"</param>
+        /// <returns>e.g. "mylds.local"</returns>
         public static string GetDomainFromFullAccountName(string fullAccountName)
         {
             return Regex.Replace(fullAccountName, RegexDomainFromFullAccountName, "$1", RegexOptions.None);
@@ -786,25 +814,58 @@ namespace ldapcp
 
         public static void GetDomainInformation(DirectoryEntry directory, out string domainName, out string domainFQDN)
         {
-            // Retrieve FQDN and domain name of current DirectoryEntry
             string distinguishedName = String.Empty;
-            domainFQDN = String.Empty;
+            domainName = domainFQDN = String.Empty;
             if (directory.Properties.Contains("distinguishedName"))
             {
                 distinguishedName = directory.Properties["distinguishedName"].Value.ToString();
-                if (distinguishedName.Contains("DC="))
-                {
-                    int start = distinguishedName.IndexOf("DC=", StringComparison.InvariantCultureIgnoreCase);
-                    string[] dnSplitted = distinguishedName.Substring(start).Split(new string[] { "DC=" }, StringSplitOptions.RemoveEmptyEntries);
-                    foreach (string dc in dnSplitted)
-                    {
-                        domainFQDN += dc.Replace(',', '.');
-                    }
-                }
+                GetDomainInformation(distinguishedName, out domainName, out domainFQDN);
             }
-            domainName = String.Empty;
-            if (directory.Properties.Contains("name")) domainName = directory.Properties["name"].Value.ToString();
-            else if (directory.Properties.Contains("cn")) domainName = directory.Properties["cn"].Value.ToString(); // Tivoli sets domain name in cn property (property name does not exist)
+            else
+            {
+                // This logic to get the domainName may not work with AD LDS:
+                // if distinguishedName = "CN=Partition1,DC=MyLDS,DC=local", then both "name" and "cn" = "Partition1", while we want to get "MyLDS"
+                // So now it's only made if the distinguishedName is not available (very unlikely)
+                if (directory.Properties.Contains("name")) domainName = directory.Properties["name"].Value.ToString();
+                else if (directory.Properties.Contains("cn")) domainName = directory.Properties["cn"].Value.ToString(); // Tivoli sets domain name in cn property (property name does not exist)
+            }
+
+            // OLD LOGIC
+            //// Retrieve FQDN and domain name of current DirectoryEntry
+            //domainFQDN = String.Empty;
+            //if (directory.Properties.Contains("distinguishedName"))
+            //{
+            //    distinguishedName = directory.Properties["distinguishedName"].Value.ToString();
+            //    if (distinguishedName.Contains("DC="))
+            //    {
+            //        int start = distinguishedName.IndexOf("DC=", StringComparison.InvariantCultureIgnoreCase);
+            //        string[] dnSplitted = distinguishedName.Substring(start).Split(new string[] { "DC=" }, StringSplitOptions.RemoveEmptyEntries);
+            //        foreach (string dc in dnSplitted)
+            //        {
+            //            domainFQDN += dc.Replace(',', '.');
+            //        }
+            //    }
+            //}
+
+            //// This change is in order to implement the same logic as in LDAPCP.SearchOrValidateWithLDAP()
+            //domainName = RequestInformation.GetFirstSubString(domainFQDN, ".");
+            ////if (directory.Properties.Contains("name")) domainName = directory.Properties["name"].Value.ToString();
+            ////else if (directory.Properties.Contains("cn")) domainName = directory.Properties["cn"].Value.ToString(); // Tivoli sets domain name in cn property (property name does not exist)
+        }
+
+        /// <summary>
+        /// Return the value from a distinguished name, or an empty string if not found.
+        /// </summary>
+        /// <param name="distinguishedNameValue">e.g. "CN=group1,CN=Users,DC=contoso,DC=local"</param>
+        /// <returns>e.g. "group1", or an empty string if not found</returns>
+        public static string GetValueFromDistinguishedName(string distinguishedNameValue)
+        {
+            int equalsIndex = distinguishedNameValue.IndexOf("=", 1);
+            int commaIndex = distinguishedNameValue.IndexOf(",", 1);
+            if (equalsIndex != -1 && commaIndex != -1)
+                return distinguishedNameValue.Substring(equalsIndex + 1, commaIndex - equalsIndex - 1);
+            else
+                return String.Empty;
         }
     }
 

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -307,24 +307,6 @@ namespace ldapcp
         }
     }
 
-    //public interface IQueryObject
-    //{
-    //    string LDAPAttribute { get; set; }
-    //    string LDAPObjectClassProp { get; set; }
-    //    string ClaimTypeProp { get; set; }
-    //    string ClaimEntityTypeProp { get; set; }
-    //    string EntityDataKey { get; set; }
-    //    bool CreateAsIdentityClaim { get; set; }
-    //    string ClaimTypeMappingName { get; set; }
-    //    string ClaimValueTypeProp { get; set; }
-    //    string PrefixToAddToValueReturnedProp { get; set; }
-    //    bool DoNotAddPrefixIfInputHasKeywordProp { get; set; }
-    //    string PrefixToBypassLookup { get; set; }
-    //    string LDAPAttributeToDisplayProp { get; set; }
-    //    bool FilterExactMatchOnlyProp { get; set; }
-    //    string AdditionalLDAPFilterProp { get; set; }
-    //}
-
     /// <summary>
     /// Defines an attribute persisted in config database
     /// </summary>
@@ -522,16 +504,6 @@ namespace ldapcp
             };
             return newAtt;
         }
-
-        //protected override void OnDeserialization()
-        //{
-        //    base.OnDeserialization();
-        //}
-
-        //public LDAPClaimProviderTrustConfiguration(string name, SPPersistedObject parent)
-        //    : base(
-        //{
-        //}
     }
 
     public class LDAPConnection : SPAutoSerializingObject
@@ -824,8 +796,8 @@ namespace ldapcp
             else
             {
                 // This logic to get the domainName may not work with AD LDS:
-                // if distinguishedName = "CN=Partition1,DC=MyLDS,DC=local", then both "name" and "cn" = "Partition1", while we want to get "MyLDS"
-                // So now it's only made if the distinguishedName is not available (very unlikely)
+                // if distinguishedName = "CN=Partition1,DC=MyLDS,DC=local", then both "name" and "cn" = "Partition1", while we expect "MyLDS"
+                // So now it's only made if the distinguishedName is not available (very unlikely codepath)
                 if (directory.Properties.Contains("name")) domainName = directory.Properties["name"].Value.ToString();
                 else if (directory.Properties.Contains("cn")) domainName = directory.Properties["cn"].Value.ToString(); // Tivoli sets domain name in cn property (property name does not exist)
             }

--- a/LDAPCP/Properties/AssemblyInfo.cs
+++ b/LDAPCP/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Security;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("5.1")]
+[assembly: AssemblyFileVersion("2017.06")]
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# LDAPCP
-This claims provider for SharePoint queries Active Directory and LDAP servers to enhance people picker with a great search experience in trusted authentication (typically ADFS).
+LDAPCP for SharePoint 2013 and 2016
+===================
+![People picker with LDAPCP](https://cloud.githubusercontent.com/assets/8788631/25440961/3b8db40a-2aa1-11e7-9070-aee808950f38.PNG)
 
-## Features
-- Works with SharePoint 2013 and SharePoint 2016. 
+Notes
+-------------
+- This project was originally hosted on [Codeplex](https://ldapcp.codeplex.com/) but I moved it here since Codeplex is [shutting down](https://blogs.msdn.microsoft.com/bharry/2017/03/31/shutting-down-codeplex/).
+- Please [click here](https://github.com/Yvand/LDAPCP/wiki/How-to-install-LDAPCP) to see how to install LDAPCP and [visit the wiki](https://github.com/Yvand/LDAPCP/wiki) to find documentation.
+
+Features
+-------------
 - Easy to configure with administration pages added in Central administration > Security. 
 - Queries multiple servers in parallel (multi-threaded connections). 
 - Populates properties (e.g. email, SIP, display name) upon permission creation. 
@@ -12,7 +18,8 @@ This claims provider for SharePoint queries Active Directory and LDAP servers to
 - Ensures thread safety. 
 - Implements augmentation to add group membership to security tokens.
 
-## Customization capabilities
+Customization capabilities
+-------------
 - Customize list of claim types, and their mapping with LDAP objects. 
 - Enable/disable augmentation globally or per LDAP connection. 
 - Customize display of permissions. 
@@ -22,5 +29,3 @@ This claims provider for SharePoint queries Active Directory and LDAP servers to
 - Hide disabled users and distribution lists. 
 - Developers can easily do a lot more by inheriting base class.
 
-## Installation
-This repo hosts the source code, please visit [project site on Codeplex](https://ldapcp.codeplex.com/) to download latest SharePoint solution package, find documentation and seek for assistance.


### PR DESCRIPTION
* Added ability to make augmentation on non Active Directory LDAP servers. There are now 2 ways:
  * Call .NET method [UserPrincipal.GetAuthorizationGroups](https://msdn.microsoft.com/en-us/library/system.directoryservices.accountmanagement.userprincipal.getauthorizationgroups.aspx) (works only with AD).
  * Read LDAP attribute memberOf/uniquememberof of the user, which should work with all LDAP servers (new method introduced in this release).
* Updated LDAPCP configuration page to let administrators choose either way to perform augmentation, individually per LDAP server.
* Improved logging to reduce amount of messages generated while providing more information, such as the time spent by LDAP server(s) to run the query