### PR TITLE
Fixed issue https://github.com/Yvand/LDAPCP/issues/16

### DIFF
--- a/LDAPCP/Properties/AssemblyInfo.cs
+++ b/LDAPCP/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Security;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("2017.06")]
+[assembly: AssemblyFileVersion("2017.09")]
 


### PR DESCRIPTION
- Fixed issue https://github.com/Yvand/LDAPCP/issues/16: Check if identity attribute exists on each result returned by LDAP to avoid an ArgumentOutOfRangeException exception.
- Reduced logging level from medium to verbose on message informing that a user key was returned.