### PR TITLE
Publish v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add method LDAPCPConfig.CreateDefaultConfiguration
+* Fix bug: randomly, LDAPCP returned results that were missing their domain name. In SharePoint logs, a DirectoryServicesCOMException error was recorded. https://github.com/Yvand/LDAPCP/issues/87
 
 ## LDAPCP 13.0.20190621.905 enhancements & bug-fixes - Published in June 21, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for LDAPCP
 
+## Unreleased
+
+* Add method LDAPCPConfig.CreateDefaultConfiguration
+
 ## LDAPCP 13.0.20190621.905 enhancements & bug-fixes - Published in June 21, 2019
 
 * Add a default mapping to populate the email of groups

--- a/LDAPCP.Tests/BackupCurrentConfig.cs
+++ b/LDAPCP.Tests/BackupCurrentConfig.cs
@@ -20,7 +20,7 @@ namespace LDAPCP.Tests
             if (Config == null)
             {
                 Trace.TraceWarning($"{DateTime.Now.ToString("s")} Configuration {UnitTestsHelper.ClaimsProviderConfigName} does not exist, create it with default settings...");
-                Config = LDAPCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, UnitTestsHelper.SPTrust.Name);
+                Config = LDAPCPConfig.CreateDefaultConfiguration(UnitTestsHelper.SPTrust.Name);
             }
             BackupConfig = Config.CopyConfiguration();
             InitializeConfiguration();

--- a/LDAPCP.Tests/BackupCurrentConfig.cs
+++ b/LDAPCP.Tests/BackupCurrentConfig.cs
@@ -20,7 +20,7 @@ namespace LDAPCP.Tests
             if (Config == null)
             {
                 Trace.TraceWarning($"{DateTime.Now.ToString("s")} Configuration {UnitTestsHelper.ClaimsProviderConfigName} does not exist, create it with default settings...");
-                Config = LDAPCPConfig.CreateDefaultConfiguration(UnitTestsHelper.SPTrust.Name);
+                Config = LDAPCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, UnitTestsHelper.SPTrust.Name);
             }
             BackupConfig = Config.CopyConfiguration();
             InitializeConfiguration();

--- a/LDAPCP.Tests/UnitTestsHelper.cs
+++ b/LDAPCP.Tests/UnitTestsHelper.cs
@@ -74,7 +74,7 @@ public class UnitTestsHelper
         LDAPCPConfig config = LDAPCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
         if (config == null)
         {
-            LDAPCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, SPTrust.Name);
+            LDAPCPConfig.CreateDefaultConfiguration(UnitTestsHelper.SPTrust.Name);
         }
 
         var service = SPFarm.Local.Services.GetValue<SPWebService>(String.Empty);

--- a/LDAPCP.Tests/UnitTestsHelper.cs
+++ b/LDAPCP.Tests/UnitTestsHelper.cs
@@ -17,8 +17,8 @@ using System.Text;
 [SetUpFixture]
 public class UnitTestsHelper
 {
-    public static readonly ldapcp.LDAPCP ClaimsProvider = new ldapcp.LDAPCP(UnitTestsHelper.ClaimsProviderName);
     public static string ClaimsProviderName => "LDAPCP";
+    public static readonly ldapcp.LDAPCP ClaimsProvider = new ldapcp.LDAPCP(UnitTestsHelper.ClaimsProviderName);
     public static readonly string ClaimsProviderConfigName = TestContext.Parameters["ClaimsProviderConfigName"];
     public static Uri TestSiteCollUri;
     public static readonly string TestSiteRelativePath = $"/sites/{TestContext.Parameters["TestSiteCollectionName"]}";
@@ -74,7 +74,7 @@ public class UnitTestsHelper
         LDAPCPConfig config = LDAPCPConfig.GetConfiguration(UnitTestsHelper.ClaimsProviderConfigName, UnitTestsHelper.SPTrust.Name);
         if (config == null)
         {
-            LDAPCPConfig.CreateDefaultConfiguration(UnitTestsHelper.SPTrust.Name);
+            LDAPCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, SPTrust.Name);
         }
 
         var service = SPFarm.Local.Services.GetValue<SPWebService>(String.Empty);

--- a/LDAPCP/Features/LDAPCP/LDAPCP.EventReceiver.cs
+++ b/LDAPCP/Features/LDAPCP/LDAPCP.EventReceiver.cs
@@ -46,7 +46,7 @@ namespace ldapcp
                     {
                         LDAPCPConfig existingConfig = LDAPCPConfig.GetConfiguration(ClaimsProviderConstants.CONFIG_NAME);
                         if (existingConfig == null)
-                            LDAPCPConfig.CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, spTrust.Name);
+                            LDAPCPConfig.CreateDefaultConfiguration(spTrust.Name);
                         else
                             ClaimsProviderLogging.Log($"[{LDAPCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.CONFIG_NAME}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
                     }

--- a/LDAPCP/Features/LDAPCP/LDAPCP.EventReceiver.cs
+++ b/LDAPCP/Features/LDAPCP/LDAPCP.EventReceiver.cs
@@ -40,15 +40,14 @@ namespace ldapcp
                 {
                     ClaimsProviderLogging svc = ClaimsProviderLogging.Local;
                     ClaimsProviderLogging.Log($"[{LDAPCP._ProviderInternalName}] Activating farm-scoped feature for claims provider \"{LDAPCP._ProviderInternalName}\"", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
-
-                    var spTrust = LDAPCP.GetSPTrustAssociatedWithCP(LDAPCP._ProviderInternalName);
-                    if (spTrust != null)
+                    LDAPCPConfig existingConfig = LDAPCPConfig.GetConfiguration(ClaimsProviderConstants.CONFIG_NAME);
+                    if (existingConfig == null)
                     {
-                        LDAPCPConfig existingConfig = LDAPCPConfig.GetConfiguration(ClaimsProviderConstants.CONFIG_NAME);
-                        if (existingConfig == null)
-                            LDAPCPConfig.CreateDefaultConfiguration(spTrust.Name);
-                        else
-                            ClaimsProviderLogging.Log($"[{LDAPCP._ProviderInternalName}] Use configuration \"{ClaimsProviderConstants.CONFIG_NAME}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
+                        LDAPCPConfig.CreateDefaultConfiguration();
+                    }
+                    else
+                    {
+                        ClaimsProviderLogging.Log($"[{LDAPCP._ProviderInternalName}] Use configuration \"{existingConfig.Name}\" found in the configuration database", TraceSeverity.High, EventSeverity.Information, ClaimsProviderLogging.TraceCategory.Configuration);
                     }
                 }
                 catch (Exception ex)

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -415,14 +415,6 @@ namespace ldapcp
         /// <param name="configToApply"></param>
         public void ApplyConfiguration(LDAPCPConfig configToApply)
         {
-            // Copy non-inherited public fields
-            // This copies persisted field SPTrustName (it doesn't have a corresponding property).
-            // Private fields should not be retrieved here, since their corresponding properties are retrieved just after.
-            FieldInfo[] fieldsToCopy = this.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            foreach (FieldInfo field in fieldsToCopy)
-            {
-                field.SetValue(this, field.GetValue(configToApply));
-            }
             // Copy non-inherited public properties
             PropertyInfo[] propertiesToCopy = this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
             foreach (PropertyInfo property in propertiesToCopy)
@@ -434,6 +426,9 @@ namespace ldapcp
                         property.SetValue(this, value);
                 }
             }
+
+            // Member SPTrustName is not exposed through a property, so it must be set explicitly
+            this.SPTrustName = configToApply.SPTrustName;
         }
 
         /// <summary>

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -496,9 +496,9 @@ namespace ldapcp
         /// <summary>
         /// Create a persisted object with default configuration of LDAPCP. If it already exists, it will be deleted.
         /// </summary>
-        /// <param name="persistedObjectID">GUID of persisted object</param>
-        /// <param name="persistedObjectName">Name of persisted object</param>
-        /// <param name="spTrustName">Name of the SPTrustedLoginProvider that LDAPCP is associated with</param>
+        /// <param name="persistedObjectID">GUID of the configuration, stored as a persisted object into SharePoint configuration database</param>
+        /// <param name="persistedObjectName">Name of the configuration, stored as a persisted object into SharePoint configuration database</param>
+        /// <param name="spTrustName">Name of the SPTrustedLoginProvider that claims provider is associated with</param>
         /// <returns></returns>
         public static LDAPCPConfig CreateConfiguration(string persistedObjectID, string persistedObjectName, string spTrustName)
         {

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -482,16 +482,40 @@ namespace ldapcp
         }
 
         /// <summary>
+        /// Create LDAPCP configuration with default settings, and save it into configuration database. If it already exists, it will be deleted.
+        /// </summary>
+        /// <param name="spTrustName">Name of the SPTrustedLoginProvider that LDAPCP is associated with</param>
+        /// <returns></returns>
+        public static LDAPCPConfig CreateDefaultConfiguration(string spTrustName)
+        {
+            if (String.IsNullOrEmpty(spTrustName))
+            {
+                throw new ArgumentNullException("spTrustName");
+            }
+
+            SPTrustedLoginProvider spTrust = LDAPCP.GetSPTrustAssociatedWithCP(LDAPCP._ProviderInternalName);
+            if (spTrust == null)
+            {
+                return null;
+            }
+            else
+            {
+                return CreateConfiguration(ClaimsProviderConstants.CONFIG_ID, ClaimsProviderConstants.CONFIG_NAME, spTrust.Name);
+            }
+        }
+
+        /// <summary>
         /// Create a persisted object with default configuration of LDAPCP. If it already exists, it will be deleted.
         /// </summary>
         /// <param name="persistedObjectID">GUID of persisted object</param>
         /// <param name="persistedObjectName">Name of persisted object</param>
+        /// <param name="spTrustName">Name of the SPTrustedLoginProvider that LDAPCP is associated with</param>
         /// <returns></returns>
         public static LDAPCPConfig CreateConfiguration(string persistedObjectID, string persistedObjectName, string spTrustName)
         {
             if (String.IsNullOrEmpty(spTrustName))
             {
-                throw new ArgumentNullException("spTrust");
+                throw new ArgumentNullException("spTrustName");
             }
 
             // Ensure it doesn't already exists and delete it if so

--- a/LDAPCP/LDAPCPConfig.cs
+++ b/LDAPCP/LDAPCPConfig.cs
@@ -482,17 +482,11 @@ namespace ldapcp
         }
 
         /// <summary>
-        /// Create LDAPCP configuration with default settings, and save it into configuration database. If it already exists, it will be deleted.
+        /// If LDAPCP is associated with a SPTrustedLoginProvider, create its configuration with default settings and save it into configuration database. If it already exists, it will be replaced.
         /// </summary>
-        /// <param name="spTrustName">Name of the SPTrustedLoginProvider that LDAPCP is associated with</param>
         /// <returns></returns>
-        public static LDAPCPConfig CreateDefaultConfiguration(string spTrustName)
+        public static LDAPCPConfig CreateDefaultConfiguration()
         {
-            if (String.IsNullOrEmpty(spTrustName))
-            {
-                throw new ArgumentNullException("spTrustName");
-            }
-
             SPTrustedLoginProvider spTrust = LDAPCP.GetSPTrustAssociatedWithCP(LDAPCP._ProviderInternalName);
             if (spTrust == null)
             {

--- a/LDAPCP/LdapcpLoggingService.cs
+++ b/LDAPCP/LdapcpLoggingService.cs
@@ -118,7 +118,7 @@ namespace ldapcp
             try
             {
 #if DEBUG
-                WriteTrace(TraceCategory.Debug, TraceSeverity.VerboseEx, message);
+                WriteTrace(TraceCategory.Debug, TraceSeverity.Verbose, message);
                 Debug.WriteLine(message);
 #else
                 // Do nothing


### PR DESCRIPTION
## Changelog

* Add method LDAPCPConfig.CreateDefaultConfiguration
* Fix bug: randomly, LDAPCP returned results that were missing their domain name. In SharePoint logs, a DirectoryServicesCOMException error was recorded. https://github.com/Yvand/LDAPCP/issues/87