### PR TITLE
Update GlobalSettings.ascx.cs

### DIFF
--- a/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
+++ b/LDAPCP/ADMIN/LDAPCP/GlobalSettings.ascx.cs
@@ -297,7 +297,7 @@ namespace ldapcp.ControlTemplates
         void UpdateAdditionalUserLdapFilter()
         {
             if (PersistedObject == null) { return; }
-            foreach (var userAttr in this.PersistedObject.ClaimTypes.Where(x => x.EntityType == DirectoryObjectType.User || x.UseMainClaimTypeOfDirectoryObject))
+            foreach (var userAttr in this.PersistedObject.ClaimTypes.Where(x => x.EntityType == DirectoryObjectType.User))
             {
                 userAttr.AdditionalLDAPFilter = this.TxtAdditionalUserLdapFilter.Text;
             }


### PR DESCRIPTION
## Changelog

- In LDAPCP global configuration page, when user clicks on "Apply to all user attributes", the filter is set also on some group entities, while it should apply only to user entities - https://github.com/Yvand/LDAPCP/issues/171

