### PR TITLE
Ignore case when comparing claim types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Change log for LDAPCP
 
+## Unreleased
+
 ## LDAPCP Second Edition v17.0.20240226.2 - Published in February 26, 2024
 
-* Initial release of LDAPCP Second Edition, a complete rewrite of current project
+* Ignore case when comparing claim types, to avoid errors when creating the configuration - https://github.com/Yvand/LDAPCP/pull/205
 
 ## LDAPCP v16.0.20230824.1 enhancements & bug-fixes - Published in August 24, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fix error when creating the configuration, due to case-sensitive test in the claim types - https://github.com/Yvand/LDAPCP/issues/204
+
 ## LDAPCP Second Edition v17.0.20240226.2 - Published in February 26, 2024
 
 * Ignore case when comparing claim types, to avoid errors when creating the configuration - https://github.com/Yvand/LDAPCP/pull/205

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
@@ -141,7 +141,7 @@ namespace Yvand.LdapClaimsProvider.Configuration
 
 
             //// Not adding those as additional attributes to avoid having too many LDAP attributes to search users in the LDAP filter
-            var nonIdentityClaimTypes = ClaimsProviderConstants.GetDefaultSettingsPerUserClaimType().Where(x => x.Key != spTrust.IdentityClaimTypeInformation.MappedClaimType);
+            var nonIdentityClaimTypes = ClaimsProviderConstants.GetDefaultSettingsPerUserClaimType().Where(x => !String.Equals(x.Key, spTrust.IdentityClaimTypeInformation.MappedClaimType, StringComparison.OrdinalIgnoreCase));
             foreach (var nonIdentityClaimType in nonIdentityClaimTypes)
             {
                 ctConfig = nonIdentityClaimType.Value;


### PR DESCRIPTION
* Fix error when creating the configuration, due to case-sensitive test in the claim types - https://github.com/Yvand/LDAPCP/issues/204