### PR TITLE
Fix error if group claim type does not exist in the trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for LDAPCP
 
+## Unreleased
+
+* Fix the error when loading the global configuration page, if the group claim type set in the LDAPCP configuration does not exist in the trust. https://github.com/Yvand/LDAPCP/issues/203
+
 ## LDAPCP Second Edition v17.0.20240226.2 - Published in February 26, 2024
 
 * Initial release of LDAPCP Second Edition, a complete rewrite of current project

--- a/Yvand.LDAPCPSE/TEMPLATE/ADMIN/LDAPCPSE/GlobalSettings.ascx.cs
+++ b/Yvand.LDAPCPSE/TEMPLATE/ADMIN/LDAPCPSE/GlobalSettings.ascx.cs
@@ -229,23 +229,34 @@ namespace Yvand.LdapClaimsProvider.Administration
             Settings.ClaimTypes.SetAdditionalLdapFilterForEntity(this.TxtUserIdAdditionalLdapFilter.Text, DirectoryObjectType.User);
 
             // Group identifier settings
-            ClaimTypeConfig groupIdConfig = Settings.ClaimTypes.GroupIdentifierConfig;
-            bool newGroupConfigObject = false;
-            if (groupIdConfig == null)
+            if (!String.Equals(this.DdlGroupClaimType.SelectedValue, "None", StringComparison.OrdinalIgnoreCase))
             {
-                groupIdConfig = new ClaimTypeConfig { DirectoryObjectType = DirectoryObjectType.Group };
-                newGroupConfigObject = true;
+                ClaimTypeConfig groupIdConfig = Settings.ClaimTypes.GroupIdentifierConfig;
+                bool newGroupConfigObject = false;
+                if (groupIdConfig == null)
+                {
+                    groupIdConfig = new ClaimTypeConfig { DirectoryObjectType = DirectoryObjectType.Group };
+                    newGroupConfigObject = true;
+                }
+                groupIdConfig.ClaimType = this.DdlGroupClaimType.SelectedValue;
+                groupIdConfig.DirectoryObjectClass = this.TxtGroupLdapClass.Text;
+                groupIdConfig.DirectoryObjectAttribute = this.TxtGroupLdapAttribute.Text;
+                groupIdConfig.DirectoryObjectAttributeForDisplayText = this.TxtGroupDisplayTextAttribute.Text;
+                groupIdConfig.ClaimValueLeadingToken = this.TxtGroupLeadingToken.Text;
+                Settings.ClaimTypes.SetSearchAttributesForEntity(this.TxtGroupAdditionalLdapAttributes.Text, groupIdConfig.DirectoryObjectClass, DirectoryObjectType.Group);
+                Settings.ClaimTypes.SetAdditionalLdapFilterForEntity(this.TxtGroupAdditionalLdapFilter.Text, DirectoryObjectType.Group);
+                if (newGroupConfigObject)
+                {
+                    Settings.ClaimTypes.Add(groupIdConfig);
+                }
             }
-            groupIdConfig.ClaimType = this.DdlGroupClaimType.SelectedValue;
-            groupIdConfig.DirectoryObjectClass = this.TxtGroupLdapClass.Text;
-            groupIdConfig.DirectoryObjectAttribute = this.TxtGroupLdapAttribute.Text;
-            groupIdConfig.DirectoryObjectAttributeForDisplayText = this.TxtGroupDisplayTextAttribute.Text;
-            groupIdConfig.ClaimValueLeadingToken = this.TxtGroupLeadingToken.Text;
-            Settings.ClaimTypes.SetSearchAttributesForEntity(this.TxtGroupAdditionalLdapAttributes.Text, groupIdConfig.DirectoryObjectClass, DirectoryObjectType.Group);
-            Settings.ClaimTypes.SetAdditionalLdapFilterForEntity(this.TxtGroupAdditionalLdapFilter.Text, DirectoryObjectType.Group);
-            if (newGroupConfigObject)
+            else
             {
-                Settings.ClaimTypes.Add(groupIdConfig);
+                ClaimTypeConfig groupIdConfig = Settings.ClaimTypes.GroupIdentifierConfig;
+                if (groupIdConfig != null)
+                {
+                    Settings.ClaimTypes.Remove(groupIdConfig);
+                }
             }
 
             // Augmentation settings

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Administration/LDAPCPSEUserControl.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Administration/LDAPCPSEUserControl.cs
@@ -3,6 +3,7 @@ using Microsoft.SharePoint.Administration;
 using Microsoft.SharePoint.Administration.Claims;
 using Microsoft.SharePoint.Utilities;
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Web.UI;
 using Yvand.LdapClaimsProvider.Configuration;
@@ -107,11 +108,13 @@ namespace Yvand.LdapClaimsProvider.Administration
             {
                 SPClaimProviderManager claimMgr = SPClaimProviderManager.Local;
                 ClaimTypeConfig idConfig = Settings.ClaimTypes.GroupIdentifierConfig;
-                if (idConfig == null)
+                string accountPrefix = String.Empty;
+                // https://github.com/Yvand/LDAPCP/issues/203 group claim type may not exist in the trust
+                if (idConfig != null && SPTrust.ClaimTypes.Contains(idConfig.ClaimType))
                 {
-                    return String.Empty;
+                    accountPrefix = claimMgr.EncodeClaim(new SPClaim(idConfig.ClaimType, String.Empty, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name)));
                 }
-                return claimMgr.EncodeClaim(new SPClaim(idConfig.ClaimType, String.Empty, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name)));
+                return accountPrefix;
             }
         }
 

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Administration/LDAPCPSEUserControl.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Administration/LDAPCPSEUserControl.cs
@@ -110,7 +110,8 @@ namespace Yvand.LdapClaimsProvider.Administration
                 ClaimTypeConfig idConfig = Settings.ClaimTypes.GroupIdentifierConfig;
                 string accountPrefix = String.Empty;
                 // https://github.com/Yvand/LDAPCP/issues/203 group claim type may not exist in the trust
-                if (idConfig != null && SPTrust.ClaimTypes.Contains(idConfig.ClaimType))
+                if (!String.IsNullOrWhiteSpace(idConfig?.ClaimType) && 
+                    SPTrust.ClaimTypeInformation.Count(x => String.Equals(x.MappedClaimType, idConfig.ClaimType, StringComparison.OrdinalIgnoreCase)) > 0)
                 {
                     accountPrefix = claimMgr.EncodeClaim(new SPClaim(idConfig.ClaimType, String.Empty, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, SPTrust.Name)));
                 }

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimTypeConfig.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimTypeConfig.cs
@@ -745,7 +745,7 @@ namespace Yvand.LdapClaimsProvider.Configuration
                     {
                         Add(newSearchAttributeConfig);
                     }
-                    catch (InvalidOperationException ex) 
+                    catch (InvalidOperationException ex)
                     {
                         // A InvalidOperationException is thrown if the LDAP attribute already exists as metadata
                         Logger.LogException(String.Empty, $"while trying to set the LDAP attribute {newAttribute} for entity type {entityType} as a search attribute", TraceCategory.Core, ex);
@@ -770,11 +770,14 @@ namespace Yvand.LdapClaimsProvider.Configuration
         public void SetAdditionalLdapFilterForEntity(string newAdditionalLdapFilter, DirectoryObjectType entityType)
         {
             ClaimTypeConfig mainConfig = GetIdentifierConfiguration(entityType);
-            mainConfig.DirectoryObjectAdditionalFilter = newAdditionalLdapFilter;
-            IEnumerable<ClaimTypeConfig> additionalConfigurations = GetAdditionalConfigurationsForEntity(entityType);
-            foreach (ClaimTypeConfig additionalConfiguration in additionalConfigurations)
+            if (mainConfig != null)
             {
-                additionalConfiguration.DirectoryObjectAdditionalFilter = newAdditionalLdapFilter;
+                mainConfig.DirectoryObjectAdditionalFilter = newAdditionalLdapFilter;
+                IEnumerable<ClaimTypeConfig> additionalConfigurations = GetAdditionalConfigurationsForEntity(entityType);
+                foreach (ClaimTypeConfig additionalConfiguration in additionalConfigurations)
+                {
+                    additionalConfiguration.DirectoryObjectAdditionalFilter = newAdditionalLdapFilter;
+                }
             }
         }
     }


### PR DESCRIPTION
## CHANGELOG

* Fix the error when loading the global configuration page, if the group claim type set in the LDAPCP configuration does not exist in the trust. https://github.com/Yvand/LDAPCP/issues/203