### PR TITLE
Add property max search results count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Fix error when creating the configuration, due to case-sensitive test in the claim types - https://github.com/Yvand/LDAPCP/issues/204
-* Fix the error when loading the global configuration page, if the group claim type set in the LDAPCP configuration does not exist in the trust. https://github.com/Yvand/LDAPCP/issues/203
+* Fix the error when loading the global configuration page, if the group claim type set in the LDAPCP configuration does not exist in the trust - https://github.com/Yvand/LDAPCP/issues/203
+* Add the property MaxSearchResultsCount, to override the SharePoint limit of the maximum number of objects that the LDAP server returns - https://github.com/Yvand/LDAPCP/issues/209
 
 ## LDAPCP Second Edition v17.0.20240226.2 - Published in February 26, 2024
 

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -321,7 +321,8 @@ namespace Yvand.LdapClaimsProvider.Configuration
             this.IncomingEntity = incomingEntity;
             this.UriContext = context;
             this.HierarchyNodeID = hierarchyNodeID;
-            this.MaxCount = maxCount;
+            this.MaxCount = settings.MaxSearchResultsCount == -1 || currentRequestType != OperationType.Search ? maxCount : settings.MaxSearchResultsCount;
+
 
             // settings.LdapConnections must be cloned locally to ensure its properties ($select / $filter) won't be updated by multiple threads
             this.LdapConnections = new List<DirectoryConnection>(settings.LdapConnections.Count);

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
@@ -468,6 +468,11 @@ namespace Yvand.LdapClaimsProvider.Configuration
                     }
                 }
             }
+
+            if (MaxSearchResultsCount < -1)
+            {
+                throw new InvalidOperationException($"The configuration is invalid because the value of property {nameof(MaxSearchResultsCount)} is < -1");
+            }
         }
 
         /// <summary>

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/LDAPProviderConfiguration.cs
@@ -52,6 +52,11 @@ namespace Yvand.LdapClaimsProvider.Configuration
         /// This property is not used by LDAPCP and is available to developers for their own needs
         /// </summary>
         string CustomData { get; }
+
+        /// <summary>
+        /// Gets how many results maximum can be returned to the people picker during a search operation
+        /// </summary>
+        int MaxSearchResultsCount { get; }
         #endregion
 
         #region LDAP specific settings
@@ -76,6 +81,7 @@ namespace Yvand.LdapClaimsProvider.Configuration
         public string EntityDisplayTextPrefix { get; set; }
         public int Timeout { get; set; } = ClaimsProviderConstants.DEFAULT_TIMEOUT;
         public string CustomData { get; set; }
+        public int MaxSearchResultsCount { get; set; } = -1;
         #endregion
 
         #region LDAP specific settings
@@ -265,6 +271,17 @@ namespace Yvand.LdapClaimsProvider.Configuration
         }
         [Persisted]
         private string _CustomData;
+
+        public int MaxSearchResultsCount
+        {
+            get
+            {
+                return _MaxSearchResultsCount;
+            }
+            private set => _MaxSearchResultsCount = value;
+        }
+        [Persisted]
+        private int _MaxSearchResultsCount = -1;
         #endregion
 
 
@@ -364,6 +381,8 @@ namespace Yvand.LdapClaimsProvider.Configuration
                 EntityDisplayTextPrefix = this.EntityDisplayTextPrefix,
                 FilterExactMatchOnly = this.FilterExactMatchOnly,
                 Timeout = this.Timeout,
+                MaxSearchResultsCount = this.MaxSearchResultsCount,
+                
                 Version = this.Version,
 
                 // Properties specific to type IEntraSettings
@@ -498,6 +517,7 @@ namespace Yvand.LdapClaimsProvider.Configuration
             this.EntityDisplayTextPrefix = settings.EntityDisplayTextPrefix;
             this.Timeout = settings.Timeout;
             this.CustomData = settings.CustomData;
+            this.MaxSearchResultsCount = settings.MaxSearchResultsCount;
 
             this.LdapConnections = settings.LdapConnections;
 

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LdapEntityProvider.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LdapEntityProvider.cs
@@ -502,7 +502,7 @@ namespace Yvand.LdapClaimsProvider
                     using (DirectorySearcher ds = new DirectorySearcher(ldapFilter))
                     {
                         ds.SearchRoot = directory;
-                        ds.SizeLimit = currentContext.MaxCount;
+                        ds.SizeLimit = currentContext.MaxCount; // Property SizeLimit is ignored if it is set to 0 (tested), and ArgumentException an exception is < 0 - https://learn.microsoft.com/en-us/dotnet/api/system.directoryservices.directorysearcher.sizelimit?view=netframework-4.8.1
                         ds.ClientTimeout = new TimeSpan(0, 0, this.Settings.Timeout); // Set the timeout in seconds
                         ds.PropertiesToLoad.Add("objectclass");
                         ds.PropertiesToLoad.Add("nETBIOSName");


### PR DESCRIPTION
## CHANGELOG

* Add the property MaxSearchResultsCount, to override the SharePoint limit of the maximum number of objects that the LDAP server returns - https://github.com/Yvand/LDAPCP/issues/209
