### PR TITLE
Fix init error if the identifier claim type is not well-known by LDAPCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221
 * Improve tests
 
 ## LDAPCP Second Edition v18.0.20240513.3 - Published in May 13, 2024

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -132,18 +132,18 @@ namespace Yvand.LdapClaimsProvider.Configuration
                         DirectoryObjectAdditionalFilter = "(!(objectClass=computer))",
                         SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("sAMAccountName") ? EntityMetadataPerLdapAttributes["sAMAccountName"] : String.Empty,
                     }
-                }
-                //{
-                //    WIF4_5.ClaimTypes.PrimarySid,
-                //    new ClaimTypeConfig
-                //    {
-                //        DirectoryObjectType = DirectoryObjectType.User,
-                //        DirectoryObjectClass = "user",
-                //        DirectoryObjectAttribute = "objectsid",
-                //        DirectoryObjectAttributeSupportsWildcard = false,
-                //        SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("objectsid") ? EntityMetadataPerLdapAttributes["objectsid"] : String.Empty,
-                //    }
-                //},
+                },
+                {   // https://github.com/Yvand/LDAPCP/issues/221: Automatically configure user SID
+                    WIF4_5.ClaimTypes.PrimarySid,
+                    new ClaimTypeConfig
+                    {
+                        DirectoryObjectType = DirectoryObjectType.User,
+                        DirectoryObjectClass = "user",
+                        DirectoryObjectAttribute = "objectsid",
+                        DirectoryObjectAttributeSupportsWildcard = false,
+                        SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("objectsid") ? EntityMetadataPerLdapAttributes["objectsid"] : String.Empty,
+                    }
+                },
             };
             // Returns a copy of the Dictionary, not the Dictionary itself, to prevent its members to be modified
             return defaultSettingsPerUserClaimType.ToList();


### PR DESCRIPTION
## CHANGELOG

* Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221