### PR TITLE
Publish LDAPCPSE v19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for LDAPCP
 
+## Unreleased
+
+* Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221
+* Improve tests
+
 ## LDAPCP Second Edition v18.0.20240513.3 - Published in May 13, 2024
 
 * Fix error when creating the configuration, due to case-sensitive test in the claim types - https://github.com/Yvand/LDAPCP/issues/204

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change log for LDAPCP
 
-## Unreleased
+## LDAPCP Second Edition v19.0 - Unreleased
 
 * Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221
-* Improve tests
+* Improve tests, to make them much easier to replay from a new test environment, and with many more users and groups
 
 ## LDAPCP Second Edition v18.0.20240513.3 - Published in May 13, 2024
 

--- a/Yvand.LDAPCPSE.Tests/AugmentationTests.cs
+++ b/Yvand.LDAPCPSE.Tests/AugmentationTests.cs
@@ -1,9 +1,5 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Yvand.LdapClaimsProvider.Tests
 {
@@ -22,26 +18,38 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetUsersMembersOfNestedGroups), null)]
+        public void TestUsersMembersOfNestedGroups(TestUser user)
         {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestAugmentationAgainstGroupsWithNestedGroupsAsMembers(user);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
 
 #if DEBUG
-        [TestCase("testLdapcpseUser_001@contoso.local", true, @"contoso.local\testLdapcpseGroup_2")]
-        public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
-        {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
-        }
+        //[TestCase("testLdapcpseUser_001@contoso.local", true, @"contoso.local\testLdapcpseGroup_2")]
+        //public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
+        //{
+        //    base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
+        //}
 #endif
     }
 
@@ -62,27 +70,31 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetUsersMembersOfNestedGroups), null)]
+        public void TestUsersMembersOfNestedGroups(TestUser user)
         {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestAugmentationAgainstGroupsWithNestedGroupsAsMembers(user);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
 
-#if DEBUG
-        [TestCase("testLdapcpseUser_001@contoso.local", true, @"contoso.local\testLdapcpseGroup_2")]
-        public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
+            TestSearchAndValidateForTestGroup(group);
         }
-#endif
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
     }
 
     public class AugmentUsingCustomConnectionAndUsingHelperTestss : ClaimsProviderTestsBase
@@ -100,27 +112,31 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetUsersMembersOfNestedGroups), null)]
+        public void TestUsersMembersOfNestedGroups(TestUser user)
         {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestAugmentationAgainstGroupsWithNestedGroupsAsMembers(user);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
 
-#if DEBUG
-        [TestCase("testLdapcpseUser_001@contoso.local", true, @"contoso.local\testLdapcpseGroup_2")]
-        public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
+            TestSearchAndValidateForTestGroup(group);
         }
-#endif
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
     }
 
     public class AugmentUsingDefaultConnectionAndUsingHelperTestss : ClaimsProviderTestsBase
@@ -140,25 +156,39 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetUsersMembersOfNestedGroups), null)]
+        public void TestUsersMembersOfNestedGroups(TestUser user)
         {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestAugmentationAgainstGroupsWithNestedGroupsAsMembers(user);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
 
 #if DEBUG
-        [TestCase("testLdapcpseUser_001@contoso.local", true, @"contoso.local\testLdapcpseGroup_2")]
-        public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
+        [TestCase("testLdapcpUser_040", "testLdapcpGroup_022")]
+        public void DebugTestUser(string upnPrefix, string groupName)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
+            TestUser user = TestEntitySourceManager.FindUser(upnPrefix);
+            TestGroup group = TestEntitySourceManager.FindGroup(groupName);
+            TestAugmentationAgainstGroup(user, group);
         }
 #endif
     }
@@ -180,19 +210,30 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-#if DEBUG
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetUsersMembersOfNestedGroups), null)]
+        public void TestUsersMembersOfNestedGroups(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupSid);
+            base.TestAugmentationAgainstGroupsWithNestedGroupsAsMembers(user);
         }
 
-        [TestCase("testLdapcpseUser_001@contoso.local", true, @"S-1-5-21-2647467245-1611586658-188888215-110602")] // testLdapcpseGroup_2
-        public void TestAugmentationOperationGroupRecursive(string claimValue, bool isMemberOfTrustedGroup, string groupValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, groupValue);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
-#endif
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
     }
 }

--- a/Yvand.LDAPCPSE.Tests/BasicConfigurationTests.cs
+++ b/Yvand.LDAPCPSE.Tests/BasicConfigurationTests.cs
@@ -18,40 +18,70 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-        [Test, TestCaseSource(typeof(SearchEntityDataSource), nameof(SearchEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
+        {
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
+
+#if DEBUG
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.AllSearchEntities), null)]
         [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public void TestSearch(SearchEntityData registrationData)
+        public void TestSearch(SearchEntityScenario registrationData)
         {
             base.TestSearchOperation(registrationData.Input, registrationData.SearchResultCount, registrationData.SearchResultSingleEntityClaimValue);
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.AllValidationEntities), null)]
         [MaxTime(UnitTestsHelper.MaxTime)]
         [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public void TestValidation(ValidateEntityData registrationData)
+        public void TestValidation(ValidateEntityScenario registrationData)
         {
             base.TestValidationOperation(registrationData);
         }
+#endif
 
-        /// <summary>
-        /// Tests if the augmentation works as expected.
-        /// </summary>
-        /// <param name="registrationData"></param>
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
-        {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
-        }
+        ///// <summary>
+        ///// Tests if the augmentation works as expected.
+        ///// </summary>
+        ///// <param name="registrationData"></param>
+        //[Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.AllValidationEntities), null)]
+        //[Repeat(UnitTestsHelper.TestRepeatCount)]
+        //public virtual void TestAugmentationOperation(ValidateEntityScenario registrationData)
+        //{
+        //    TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+        //}
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
-        {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
-        }
+        //[TestCase("FakeAccount", false)]
+        //[TestCase("yvand@contoso.local", true)]
+        //public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        //{
+        //    base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+        //}
 
 #if DEBUG
+        [TestCase("testLdapcpUser_001")]
+        [TestCase("testLdapcpUser_007")]
+        public void DebugTestUser(string upnPrefix)
+        {
+            TestUser user = TestEntitySourceManager.FindUser(upnPrefix);
+            base.TestSearchAndValidateForTestUser(user);
+        }
+
         ////[TestCaseSource(typeof(SearchEntityDataSourceCollection))]
         //public void DEBUG_SearchEntitiesFromCollection(string inputValue, string expectedCount, string expectedClaimValue)
         //{
@@ -61,9 +91,10 @@ namespace Yvand.LdapClaimsProvider.Tests
         //}
 
         //[TestCase(@"group\ch", 1, @"contoso.local\group\chartest")]
-        [TestCase(@"test_special)", 1, @"test_special_char@contoso.local")]
+        [TestCase(@"test_special)", 1, @"testLdapcpUser_003@contoso.local")]
+        [TestCase(@"firstname_002", 1, @"testLdapcpUser_002@contoso.local")]
         //[TestCase(@"group\ch", 1, @"group\chartest")]
-        [TestCase(@"testLdapcpseUser_001", 1, @"testLdapcpseUser_001@contoso.local")]
+        [TestCase(@"testLdapcpUser_001", 1, @"testLdapcpUser_001@contoso.local")]
         public void TestSearch(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
         {
             base.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);

--- a/Yvand.LDAPCPSE.Tests/BypassDirectoryTests.cs
+++ b/Yvand.LDAPCPSE.Tests/BypassDirectoryTests.cs
@@ -7,11 +7,13 @@ namespace Yvand.LdapClaimsProvider.Tests
     [Parallelizable(ParallelScope.Children)]
     public class BypassDirectoryOnClaimTypesTests : ClaimsProviderTestsBase
     {
+        const string PrefixBypassUserSearch = "bypass-user:";
+        const string PrefixBypassGroupSearch = "bypass-group:";
         protected override void InitializeSettings()
         {
             base.InitializeSettings();
-            Settings.ClaimTypes.UserIdentifierConfig.LeadingKeywordToBypassDirectory = "bypass-user:";
-            Settings.ClaimTypes.GroupIdentifierConfig.LeadingKeywordToBypassDirectory = "bypass-group:";
+            Settings.ClaimTypes.UserIdentifierConfig.LeadingKeywordToBypassDirectory = PrefixBypassUserSearch;
+            Settings.ClaimTypes.GroupIdentifierConfig.LeadingKeywordToBypassDirectory = PrefixBypassGroupSearch;
             base.ApplySettings();
         }
 
@@ -19,6 +21,26 @@ namespace Yvand.LdapClaimsProvider.Tests
         public override void CheckSettingsTest()
         {
             base.CheckSettingsTest();
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
+        {
+            // Normal scenario
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+
+            // Scenario with bypass keyword passed
+            // TestSearchAndValidateForTestUser() uses the SamAccountName is used as the input so it should be set with the expected claim value
+            user.SamAccountName = $"{PrefixBypassUserSearch}{user.UserPrincipalName}";
+            base.TestSearchAndValidateForTestUser(user);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
 
         [TestCase("bypass-user:externalUser@contoso.com", 1, "externalUser@contoso.com")]
@@ -35,20 +57,6 @@ namespace Yvand.LdapClaimsProvider.Tests
             {
                 TestValidationOperation(UnitTestsHelper.SPTrust.IdentityClaimTypeInformation.MappedClaimType, expectedClaimValue, true);
             }
-        }
-
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
-        {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
-        }
-
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
-        {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
         }
     }
 
@@ -77,18 +85,24 @@ namespace Yvand.LdapClaimsProvider.Tests
             TestValidationOperation(base.GroupIdentifierClaimType, UnitTestsHelper.RandomClaimValue, true);
         }
 
-        [Test, TestCaseSource(typeof(ValidateEntityDataSource), nameof(ValidateEntityDataSource.GetTestData), new object[] { EntityDataSourceType.AllAccounts })]
-        [Repeat(UnitTestsHelper.TestRepeatCount)]
-        public virtual void TestAugmentationOperation(ValidateEntityData registrationData)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            TestAugmentationOperation(registrationData.ClaimValue, registrationData.IsMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupName);
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
         }
     }
 }

--- a/Yvand.LDAPCPSE.Tests/Setup/Populate-ActiveDirectory.ps1
+++ b/Yvand.LDAPCPSE.Tests/Setup/Populate-ActiveDirectory.ps1
@@ -1,0 +1,201 @@
+#Requires -Modules ActiveDirectory
+
+<#
+.SYNOPSIS
+    Creates the users and groups in Active Directory, required to run the unit tests in LDAPCP project
+.DESCRIPTION
+    It creates the objects only if they do not exist (no overwrite).
+    Group membership is always re-applied.
+.LINK
+    https://github.com/Yvand/LDAPCP/
+#>
+
+
+$domainFqdn = (Get-ADDomain -Current LocalComputer).DNSRoot
+$domainDN = (Get-ADDomain -Current LocalComputer).DistinguishedName
+$ouName = "ldapcp"
+$ouDN = "OU=$($ouName),$($domainDN)"
+
+$exportedUsersFullFilePath = "C:\YvanData\dev\LDAPCP_Tests_Users.csv"
+$exportedGroupsFullFilePath = "C:\YvanData\dev\LDAPCP_Tests_Groups.csv"
+
+try {
+    Get-ADOrganizationalUnit -Identity $ouDN | Out-Null
+}
+catch {
+    Write-Warning "Could not get the OU $ouDN : $($_.Exception.Message)"
+    return
+}
+
+$userNamePrefix = "testLdapcpUser_"
+$groupNamePrefix = "testLdapcpGroup_"
+$usersCount = 100
+$groupsCount = 50
+
+$confirmation = Read-Host "Connected to domain '$domainFqdn' and about to process users starting with '$userNamePrefix' and groups starting with '$groupNamePrefix'. Are you sure you want to proceed? [y/n]"
+if ($confirmation -ne 'y') {
+    Write-Warning -Message "Aborted."
+    return
+}
+
+$usersWithSpecificSettings = @( 
+    @{ UserPrincipalName = "$($userNamePrefix)001@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)002@$($domainFqdn)"; UserAttributes = @{ "GivenName" = "firstname_002" } }
+    @{ UserPrincipalName = "$($userNamePrefix)003@$($domainFqdn)"; UserAttributes = @{ "GivenName" = "test_special)" } }
+    @{ UserPrincipalName = "$($userNamePrefix)007@$($domainFqdn)"; UserAttributes = @{ "GivenName" = "James"; "displayName" = "James Bond" } }
+    @{ UserPrincipalName = "$($userNamePrefix)010@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)011@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)012@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)013@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)014@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)015@$($domainFqdn)"; IsMemberOfAllGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)020@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)024@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)028@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)032@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)036@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)040@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+    @{ UserPrincipalName = "$($userNamePrefix)042@$($domainFqdn)"; IsMemberOfNestedGroups = $true }
+)
+
+$groupsWithSpecificSettings = @(
+    @{
+        GroupName        = "$($groupNamePrefix)001"
+        EveryoneIsMember = $true
+    },
+    @{
+        GroupName        = "$($groupNamePrefix)005"
+        EveryoneIsMember = $true
+    },
+    @{
+        GroupName        = "$($groupNamePrefix)018"
+        EveryoneIsMember = $true
+    },
+    @{
+        GroupName     = "$($groupNamePrefix)020"
+        IsNestedGroup = $true
+    },
+    @{
+        GroupName     = "$($groupNamePrefix)021"
+        IsNestedGroup = $true
+    },
+    @{
+        GroupName     = "$($groupNamePrefix)022"
+        IsNestedGroup = $true
+    },
+    @{
+        GroupName     = "$($groupNamePrefix)023"
+        IsNestedGroup = $true
+    },
+    @{
+        GroupName              = "$($groupNamePrefix)025"
+        NestedGroupsAreMembers = $true
+    },
+    @{
+        GroupName              = "$($groupNamePrefix)026"
+        NestedGroupsAreMembers = $true
+    },
+    @{
+        GroupName        = "$($groupNamePrefix)025"
+        EveryoneIsMember = $true
+    },
+    @{
+        GroupName        = "$($groupNamePrefix)038"
+        EveryoneIsMember = $true
+    }
+)
+
+$temporaryPassword = @(
+    (0..9 | Get-Random ),
+    ('!', '@', '#', '$', '%', '^', '&', '*', '?', ';', '+' | Get-Random),
+    (0..9 | Get-Random ),
+    [char](65..90 | Get-Random),
+    (0..9 | Get-Random ),
+    [char](97..122 | Get-Random),
+    [char](97..122 | Get-Random),
+    (0..9 | Get-Random ),
+    [char](97..122 | Get-Random)
+) -Join ''
+
+# Bulk add users if they do not already exist
+$allUsers = @()
+$allUsersAccountNames = @()
+for ($i = 1; $i -le $usersCount; $i++) {
+    $accountName = "$($userNamePrefix)$("{0:D3}" -f $i)"
+    $allUsersAccountNames += $accountName
+    $user = $(try { Get-ADUser $accountName } catch { $null })
+    if ($null -eq $user) {
+        $userPrincipalName = "$($accountName)@$($domainFqdn)"
+        $additionalUserAttributes = New-Object -TypeName HashTable
+        $userHasSpecificAttributes = [System.Linq.Enumerable]::FirstOrDefault($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $userPrincipalName })
+        if ($null -ne $userHasSpecificAttributes.UserAttributes) {
+            $additionalUserAttributes = $userHasSpecificAttributes.UserAttributes
+        }
+        $additionalUserAttributes.Add("mail", $userPrincipalName)
+
+        $securePassword = ConvertTo-SecureString $temporaryPassword -AsPlainText -Force
+        New-ADUser -Name "$accountName" -UserPrincipalName $userPrincipalName -OtherAttributes $additionalUserAttributes -Accountpassword $securePassword -Enabled $true -Path $ouDN
+        Write-Host "Created user $accountName" -ForegroundColor Green
+    }
+    $user = Get-ADUser $accountName -Properties displayName, mail
+    $allUsers += $user
+}
+
+# Bulk add groups if they do not already exist AND set their membership
+$usersMemberOfAllGroups = [System.Linq.Enumerable]::Where($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.IsMemberOfAllGroups -eq $true }) | Select-Object -Property @{ Name = "AccountName"; Expression = { $_.UserPrincipalName.Split("@")[0] } }
+$usersMemberOfNestedGroups = [System.Linq.Enumerable]::Where($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.IsMemberOfNestedGroups -eq $true }) | Select-Object -Property @{ Name = "AccountName"; Expression = { $_.UserPrincipalName.Split("@")[0] } }
+$nestedGroups = [System.Linq.Enumerable]::Where($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.IsNestedGroup -eq $true })
+$allGroups = @()
+for ($i = 1; $i -le $groupsCount; $i++) {
+    $groupName = "$($groupNamePrefix)$("{0:D3}" -f $i)"
+    $group = $(try { Get-ADGroup -Identity $groupName } catch { $null })
+    if ($null -eq $group) {
+        New-ADGroup -Name $groupName -DisplayName $groupName -GroupCategory Security -GroupScope Global -Path $ouDN
+        Write-Host "Created group $groupName" -ForegroundColor Green
+    }
+    $group = Get-ADGroup -Identity $groupName
+    $allGroups += $group
+
+    # Remove and re-add all group members
+    Get-ADGroupMember $groupName | ForEach-Object { Remove-ADGroupMember -Identity $groupName -Members $_ -Confirm:$false }
+    Write-Host "Removed all members of group $groupName" -ForegroundColor Green
+    
+    $groupSettings = [System.Linq.Enumerable]::FirstOrDefault($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.GroupName -like $groupName })
+    if ($null -ne $groupSettings -and $groupSettings.ContainsKey("EveryoneIsMember") -and $groupSettings["EveryoneIsMember"] -eq $true) {
+        # Add all users as members
+        Add-ADGroupMember -Identity $groupName -Members $allUsersAccountNames
+        Write-Host "Added all test users as members of group $groupName" -ForegroundColor Green
+    }
+    else {
+        # Only users with IsMemberOfAllGroups true are members of this group
+        $group | Add-ADGroupMember -Members $usersMemberOfAllGroups.AccountName
+        Write-Host "Added users with EveryoneIsMember = true as members of group $groupName" -ForegroundColor Green
+    }
+    
+    if ($null -ne $groupSettings -and $groupSettings.ContainsKey("IsNestedGroup") -and $groupSettings["IsNestedGroup"] -eq $true) {
+        # Also add users with IsMemberOfNestedGroups
+        $group | Add-ADGroupMember -Members $usersMemberOfNestedGroups.AccountName
+        Write-Host "Added users with IsMemberOfNestedGroups = true as members of group $groupName" -ForegroundColor Green
+    } elseif ($null -ne $groupSettings -and $groupSettings.ContainsKey("NestedGroupsAreMembers") -and $groupSettings["NestedGroupsAreMembers"] -eq $true) {
+        # Also add nested groups since this group has NestedGroupsAreMembers
+        $group | Add-ADGroupMember -Members $nestedGroups.GroupName
+        Write-Host "Added nested groups to group $groupName because it has property NestedGroupsAreMembers true" -ForegroundColor Green
+    }    
+}
+
+# export users and groups to their CSV file
+$allUsers | 
+Select-Object -Property UserPrincipalName, SamAccountName, Mail, GivenName, DisplayName, DistinguishedName, SID,
+@{ Name = "IsMemberOfAllGroups"; Expression = { if ([System.Linq.Enumerable]::FirstOrDefault($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $_.UserPrincipalName }).IsMemberOfAllGroups) { $true } else { $false } } },
+@{ Name = "IsMemberOfNestedGroups"; Expression = { if ([System.Linq.Enumerable]::FirstOrDefault($usersWithSpecificSettings, [Func[object, bool]] { param($x) $x.UserPrincipalName -like $_.UserPrincipalName }).IsMemberOfNestedGroups) { $true } else { $false } } } |
+Export-Csv -Path $exportedUsersFullFilePath -NoTypeInformation
+Write-Host "Exported test users to CSV file $($exportedUsersFullFilePath)" -ForegroundColor Green
+
+$allGroups | 
+Select-Object -Property SamAccountName, DistinguishedName, SID, 
+@{ Name = "EveryoneIsMember"; Expression = { if ([System.Linq.Enumerable]::FirstOrDefault($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.GroupName -like $_.SamAccountName }).EveryoneIsMember) { $true } else { $false } } },
+@{ Name = "IsNestedGroup"; Expression = { if ([System.Linq.Enumerable]::FirstOrDefault($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.GroupName -like $_.SamAccountName }).IsNestedGroup) { $true } else { $false } } },
+@{ Name = "NestedGroupsAreMembers"; Expression = { if ([System.Linq.Enumerable]::FirstOrDefault($groupsWithSpecificSettings, [Func[object, bool]] { param($x) $x.GroupName -like $_.SamAccountName }).NestedGroupsAreMembers) { $true } else { $false } } },
+@{ Name = "AccountNameFqdn"; Expression = { "$($domainFqdn)\$($_.SamAccountName)" } } |
+Export-Csv -Path $exportedGroupsFullFilePath -NoTypeInformation
+Write-Host "Exported test groups to CSV file $($exportedGroupsFullFilePath)" -ForegroundColor Green

--- a/Yvand.LDAPCPSE.Tests/UnitTestsHelper.cs
+++ b/Yvand.LDAPCPSE.Tests/UnitTestsHelper.cs
@@ -16,42 +16,36 @@ namespace Yvand.LdapClaimsProvider.Tests
     [SetUpFixture]
     public class UnitTestsHelper
     {
-        public static readonly LDAPCPSE ClaimsProvider = new LDAPCPSE(TestContext.Parameters["ClaimsProviderName"]);
-        public static SPTrustedLoginProvider SPTrust => SPSecurityTokenServiceManager.Local.TrustedLoginProviders.FirstOrDefault(x => String.Equals(x.ClaimProviderName, TestContext.Parameters["ClaimsProviderName"], StringComparison.InvariantCultureIgnoreCase));
+        public static readonly string ClaimsProviderName = TestContext.Parameters["ClaimsProviderName"];
+        public static readonly LDAPCPSE ClaimsProvider = new LDAPCPSE(ClaimsProviderName);
+        public static SPTrustedLoginProvider SPTrust => Utils.GetSPTrustAssociatedWithClaimsProvider(ClaimsProviderName);
         public static Uri TestSiteCollUri;
-        public static string TestSiteRelativePath => $"/sites/{TestContext.Parameters["TestSiteCollectionName"]}";
+        public static string TestSiteRelativePath => $"/sites/{ClaimsProviderName}.UnitTests";
         public const int MaxTime = 50000;
+        public const int TestRepeatCount = 1;
         public static string FarmAdmin => TestContext.Parameters["FarmAdmin"];
         public static string DomainFqdn => TestContext.Parameters["DomainFqdn"];
-        public static string Domain => TestContext.Parameters["Domain"];
-#if DEBUG
-        public const int TestRepeatCount = 1;
-#else
-    public const int TestRepeatCount = 20;
-#endif
 
         public static string RandomClaimType => "http://schemas.yvand.net/ws/claims/random";
         public static string RandomClaimValue => "IDoNotExist";
         public static string RandomDirectoryObjectClass => "randomClass";
         public static string RandomDirectoryObjectAttribute => "randomAttribute";
 
-        public static string ValidGroupClaimType => TestContext.Parameters["ValidGroupClaimType"];
-        public static string ValidGroupName => TestContext.Parameters["ValidGroupName"];
-        public const string ValidGroupSid = "S-1-5-21-2647467245-1611586658-188888215-11601"; //=> TestContext.Parameters["ValidTrustedGroupName"]; // CONTOSO\group1
-        public const string ValidUserSid = "S-1-5-21-2647467245-1611586658-188888215-107206"; // => TestContext.Parameters["ValidUserSid"]; // CONTOSO\testLdapcpseUser_001
+        public static string GroupsClaimType => TestContext.Parameters["GroupsClaimType"];
 
-        public static string AzureTenantsJsonFile => TestContext.Parameters["LdapConnections"];
+        public static string LdapConnectionsJsonFile => TestContext.Parameters["LdapConnectionsJsonFile"];
         public static string DataFile_AllAccounts_Search => TestContext.Parameters["DataFile_AllAccounts_Search"];
         public static string DataFile_AllAccounts_Validate => TestContext.Parameters["DataFile_AllAccounts_Validate"];
+        public static string DataFile_TestUsers => TestContext.Parameters["DataFile_TestUsers"];
+        public static string DataFile_TestGroups => TestContext.Parameters["DataFile_TestGroups"];
         static TextWriterTraceListener Logger { get; set; }
         public static LdapProviderConfiguration PersistedConfiguration;
         private static ILdapProviderSettings OriginalSettings;
 
-
         [OneTimeSetUp]
         public static void InitializeSiteCollection()
         {
-            Logger = new TextWriterTraceListener(TestContext.Parameters["TestLogFileName"]);
+            Logger = new TextWriterTraceListener($"{ClaimsProviderName}IntegrationTests.log");
             Trace.Listeners.Add(Logger);
             Trace.AutoFlush = true;
             Trace.TraceInformation($"{DateTime.Now.ToString("s")} [SETUP] Start integration tests of {ClaimsProvider.Name} {FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(LDAPCPSE)).Location).FileVersion}.");
@@ -82,7 +76,7 @@ namespace Yvand.LdapClaimsProvider.Tests
 
 #if DEBUG
             TestSiteCollUri = new Uri($"http://spsites{TestSiteRelativePath}");
-            return; // Uncommented when debugging from unit tests
+            //return; // Uncommented when debugging from unit tests
 #endif
 
             var service = SPFarm.Local.Services.GetValue<SPWebService>(String.Empty);
@@ -110,8 +104,9 @@ namespace Yvand.LdapClaimsProvider.Tests
             Uri waRootAuthority = wa.AlternateUrls[0].Uri;
             TestSiteCollUri = new Uri($"{waRootAuthority.GetLeftPart(UriPartial.Authority)}{TestSiteRelativePath}");
             SPClaimProviderManager claimMgr = SPClaimProviderManager.Local;
-            string encodedGroupClaim = claimMgr.EncodeClaim(new SPClaim(ValidGroupClaimType, ValidGroupName, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name)));
-            SPUserInfo groupInfo = new SPUserInfo { LoginName = encodedGroupClaim, Name = ValidGroupName };
+            string trustedGroupName = TestEntitySourceManager.GetOneGroup().AccountNameFqdn;
+            string encodedGroupClaim = claimMgr.EncodeClaim(new SPClaim(GroupsClaimType, trustedGroupName, ClaimValueTypes.String, SPOriginalIssuers.Format(SPOriginalIssuerType.TrustedProvider, UnitTestsHelper.SPTrust.Name)));
+            SPUserInfo groupInfo = new SPUserInfo { LoginName = encodedGroupClaim, Name = trustedGroupName };
 
             FileVersionInfo spAssemblyVersion = FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(SPSite)).Location);
             string spSiteTemplate = "STS#3"; // modern team site template
@@ -179,15 +174,6 @@ namespace Yvand.LdapClaimsProvider.Tests
         }
     }
 
-    //public class SearchEntityDataSourceCollection : IEnumerable
-    //{
-    //    public IEnumerator GetEnumerator()
-    //    {
-    //        yield return new[] { "AADGroup1", "1", "5b0f6c56-c87f-44c3-9354-56cba03da433" };
-    //        yield return new[] { "AADGroupTes", "1", "99abdc91-e6e0-475c-a0ba-5014f91de853" };
-    //    }
-    //}
-
     public enum ResultEntityType
     {
         None,
@@ -196,79 +182,232 @@ namespace Yvand.LdapClaimsProvider.Tests
         Group,
     }
 
-    public enum EntityDataSourceType
+    public abstract class TestEntity : ICloneable
     {
-        AllAccounts,
-        UPNB2BGuestAccounts
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
+
+        public abstract void SetEntityFromDataSourceRow(Row row);
     }
 
-    public class SearchEntityData
+    public class TestUser : TestEntity
+    {
+        public string UserPrincipalName;
+        public string SamAccountName;
+        public string Mail;
+        public string GivenName;
+        public string DisplayName;
+        public string DistinguishedName;
+        public string SID;
+        public bool IsMemberOfAllGroups;
+        public bool IsMemberOfNestedGroups;
+
+        public override void SetEntityFromDataSourceRow(Row row)
+        {
+            UserPrincipalName = row["userPrincipalName"];
+            SamAccountName = row["SamAccountName"];
+            Mail = row["mail"];
+            GivenName = row["givenName"];
+            DisplayName = row["displayName"];
+            DistinguishedName = row["DistinguishedName"];
+            SID = row["SID"];
+            IsMemberOfAllGroups = Convert.ToBoolean(row["IsMemberOfAllGroups"]);
+            IsMemberOfNestedGroups = Convert.ToBoolean(row["IsMemberOfNestedGroups"]);
+        }
+    }
+
+    public class TestGroup : TestEntity
+    {
+        public string SamAccountName;
+        public string DistinguishedName;
+        public string SID;
+        public bool EveryoneIsMember;
+        public string AccountNameFqdn;
+        public bool IsNestedGroup;
+        public bool NestedGroupsAreMembers;
+
+        public override void SetEntityFromDataSourceRow(Row row)
+        {
+            SamAccountName = row["SamAccountName"];
+            DistinguishedName = row["DistinguishedName"];
+            SID = row["SID"];
+            EveryoneIsMember = Convert.ToBoolean(row["EveryoneIsMember"]);
+            AccountNameFqdn = row["AccountNameFqdn"];
+            IsNestedGroup = Convert.ToBoolean(row["IsNestedGroup"]);
+            NestedGroupsAreMembers = Convert.ToBoolean(row["NestedGroupsAreMembers"]);
+        }
+    }
+
+    public class SearchEntityScenario : TestEntity
     {
         public string Input;
         public int SearchResultCount;
         public string SearchResultSingleEntityClaimValue;
         public ResultEntityType SearchResultEntityTypes;
         public bool ExactMatch;
-    }
 
-    public class SearchEntityDataSource
-    {
-        public static IEnumerable<TestCaseData> GetTestData(EntityDataSourceType entityDataSourceType)
+        public override void SetEntityFromDataSourceRow(Row row)
         {
-            string csvPath = UnitTestsHelper.DataFile_AllAccounts_Search;
-            DataTable dt = DataTable.New.ReadCsv(csvPath);
-            foreach (Row row in dt.Rows)
-            {
-                var registrationData = new SearchEntityData();
-                registrationData.Input = row["Input"];
-                registrationData.SearchResultCount = Convert.ToInt32(row["SearchResultCount"]);
-                registrationData.SearchResultSingleEntityClaimValue = row["SearchResultSingleEntityClaimValue"];
-                registrationData.SearchResultEntityTypes = (ResultEntityType)Enum.Parse(typeof(ResultEntityType), row["SearchResultEntityTypes"]);
-                registrationData.ExactMatch = Convert.ToBoolean(row["ExactMatch"]);
-                yield return new TestCaseData(new object[] { registrationData });
-            }
-        }
-
-        //public class ReadCSV
-        //{
-        //    public void GetValue()
-        //    {
-        //        TextReader tr1 = new StreamReader(@"c:\pathtofile\filename", true);
-
-        //        var Data = tr1.ReadToEnd().Split('\n')
-        //        .Where(l => l.Length > 0)  //nonempty strings
-        //        .Skip(1)               // skip header 
-        //        .Select(s => s.Trim())   // delete whitespace
-        //        .Select(l => l.Split(',')) // get arrays of values
-        //        .Select(l => new { Field1 = l[0], Field2 = l[1], Field3 = l[2] });
-        //    }
-        //}
-    }
-
-    public class ValidateEntityDataSource
-    {
-        public static IEnumerable<TestCaseData> GetTestData(EntityDataSourceType entityDataSourceType)
-        {
-            string csvPath = UnitTestsHelper.DataFile_AllAccounts_Validate;
-            DataTable dt = DataTable.New.ReadCsv(csvPath);
-
-            foreach (Row row in dt.Rows)
-            {
-                var registrationData = new ValidateEntityData();
-                registrationData.ClaimValue = row["ClaimValue"];
-                registrationData.ShouldValidate = Convert.ToBoolean(row["ShouldValidate"]);
-                registrationData.IsMemberOfTrustedGroup = Convert.ToBoolean(row["IsMemberOfTrustedGroup"]);
-                registrationData.EntityType = (ResultEntityType)Enum.Parse(typeof(ResultEntityType), row["EntityType"]);
-                yield return new TestCaseData(new object[] { registrationData });
-            }
+            Input = row["Input"];
+            SearchResultCount = Convert.ToInt32(row["SearchResultCount"]);
+            SearchResultSingleEntityClaimValue = row["SearchResultSingleEntityClaimValue"];
+            SearchResultEntityTypes = (ResultEntityType)Enum.Parse(typeof(ResultEntityType), row["SearchResultEntityTypes"]);
+            ExactMatch = Convert.ToBoolean(row["ExactMatch"]);
         }
     }
 
-    public class ValidateEntityData
+    public class ValidateEntityScenario : TestEntity
     {
         public string ClaimValue;
         public bool ShouldValidate;
         public bool IsMemberOfTrustedGroup;
         public ResultEntityType EntityType;
+
+        public override void SetEntityFromDataSourceRow(Row row)
+        {
+            ClaimValue = row["ClaimValue"];
+            ShouldValidate = Convert.ToBoolean(row["ShouldValidate"]);
+            IsMemberOfTrustedGroup = Convert.ToBoolean(row["IsMemberOfTrustedGroup"]);
+            EntityType = (ResultEntityType)Enum.Parse(typeof(ResultEntityType), row["EntityType"]);
+        }
+    }
+
+    public class TestEntitySource<T> where T : TestEntity, new()
+    {
+        private object _LockInitEntitiesList = new object();
+        private bool EntitiesReady = false;
+        private List<T> _Entities;
+        public List<T> Entities
+        {
+            get
+            {
+                if (EntitiesReady) { return _Entities; }
+                lock (_LockInitEntitiesList)
+                {
+                    if (EntitiesReady) { return _Entities; }
+                    _Entities = new List<T>();
+                    foreach (T entity in ReadDataSource())
+                    {
+                        _Entities.Add(entity);
+                    }
+                    EntitiesReady = true;
+                    Trace.TraceInformation($"{DateTime.Now:s} [{typeof(T).Name}] Initialized List of {nameof(Entities)} with {Entities.Count} items.");
+                    return _Entities;
+                }
+            }
+        }
+
+        private Random RandomNumber = new Random();
+        private string DataSourceFilePath;
+
+        public TestEntitySource(string dataSourceFilePath)
+        {
+            DataSourceFilePath = dataSourceFilePath;
+        }
+
+        private IEnumerable<T> ReadDataSource()
+        {
+            DataTable dt = DataTable.New.ReadCsv(DataSourceFilePath);
+            foreach (Row row in dt.Rows)
+            {
+                T entity = new T();
+                entity.SetEntityFromDataSourceRow(row);
+                yield return entity;
+            }
+        }
+
+        public IEnumerable<T> GetSomeEntities(int count, Func<T, bool> filter = null)
+        {
+            IEnumerable<T> entitiesFiltered = Entities.Where(filter ?? (x => true));
+            int entitiesFilteredCount = entitiesFiltered.Count();
+            if (count > entitiesFilteredCount) { count = entitiesFilteredCount; }
+            for (int i = 0; i < count; i++)
+            {
+                int randomIdx = RandomNumber.Next(0, entitiesFilteredCount);
+                yield return entitiesFiltered.ElementAt(randomIdx).Clone() as T;
+            }
+        }
+    }
+
+    public class TestEntitySourceManager
+    {
+#if DEBUG
+
+        private static TestEntitySource<SearchEntityScenario> SearchTestsSource = new TestEntitySource<SearchEntityScenario>(UnitTestsHelper.DataFile_AllAccounts_Search);
+        public static List<SearchEntityScenario> AllSearchEntities
+        {
+            get => SearchTestsSource.Entities;
+        }
+        private static TestEntitySource<ValidateEntityScenario> ValidationTestsSource = new TestEntitySource<ValidateEntityScenario>(UnitTestsHelper.DataFile_AllAccounts_Validate);
+        public static List<ValidateEntityScenario> AllValidationEntities
+        {
+            get => ValidationTestsSource.Entities;
+        }
+#endif
+        private static TestEntitySource<TestUser> TestUsersSource = new TestEntitySource<TestUser>(UnitTestsHelper.DataFile_TestUsers);
+        public static List<TestUser> AllTestUsers
+        {
+            get => TestUsersSource.Entities;
+        }
+        private static TestEntitySource<TestGroup> TestGroupsSource = new TestEntitySource<TestGroup>(UnitTestsHelper.DataFile_TestGroups);
+        public static List<TestGroup> AllTestGroups
+        {
+            get => TestGroupsSource.Entities;
+        }
+        public const int MaxNumberOfUsersToTest = 100;
+        public const int MaxNumberOfGroupsToTest = 50;
+
+        public static IEnumerable<TestUser> GetSomeUsers(int count)
+        {
+            return TestUsersSource.GetSomeEntities(count, null);
+        }
+
+        public static IEnumerable<TestUser> GetUsersMembersOfAllGroups()
+        {
+            Func<TestUser, bool> filter = x => x.IsMemberOfAllGroups == true;
+            return TestUsersSource.GetSomeEntities(Int16.MaxValue, filter);
+        }
+
+        public static IEnumerable<TestUser> GetUsersMembersOfNestedGroups()
+        {
+            Func<TestUser, bool> filter = x => x.IsMemberOfNestedGroups == true;
+            return TestUsersSource.GetSomeEntities(Int16.MaxValue, filter);
+        }
+
+        public static TestUser FindUser(string upnPrefix)
+        {
+            Func<TestUser, bool> filter = x => x.UserPrincipalName.StartsWith(upnPrefix);
+            return TestUsersSource.GetSomeEntities(1, filter).First();
+        }
+
+        public static IEnumerable<TestGroup> GetSomeGroups(int count)
+        {
+            return TestGroupsSource.GetSomeEntities(count);
+        }
+
+        public static IEnumerable<TestGroup> GetNestedGroups(int count)
+        {
+            Func<TestGroup, bool> filter = x => x.IsNestedGroup == true;
+            return TestGroupsSource.GetSomeEntities(count, filter);
+        }
+
+        public static IEnumerable<TestGroup> GetGroupsWithNestedGroupsAsMembers(int count)
+        {
+            Func<TestGroup, bool> filter = x => x.NestedGroupsAreMembers == true;
+            return TestGroupsSource.GetSomeEntities(count, filter);
+        }
+
+        public static TestGroup GetOneGroup()
+        {
+            return TestGroupsSource.GetSomeEntities(1, null).First();
+        }
+
+        public static TestGroup FindGroup(string groupName)
+        {
+            Func<TestGroup, bool> filter = x => String.Equals(x.SamAccountName, groupName, StringComparison.OrdinalIgnoreCase);
+            return TestGroupsSource.GetSomeEntities(1, filter).First();
+        }
     }
 }

--- a/Yvand.LDAPCPSE.Tests/UseSidAttributeForPermissionTests.cs
+++ b/Yvand.LDAPCPSE.Tests/UseSidAttributeForPermissionTests.cs
@@ -23,16 +23,22 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-#if DEBUG
-        [TestCase(UnitTestsHelper.ValidUserSid, 1, UnitTestsHelper.ValidUserSid)]
-        [TestCase(@"testLdapcpseUser_001", 1, UnitTestsHelper.ValidUserSid)]
-        [TestCase(@"S-1-5-21-0000000000-1611586658-188888215-107206", 0, @"")]
-        public void TestSidAttribute(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);
-            base.TestValidationOperation(base.UserIdentifierClaimType, expectedEntityClaimValue, expectedResultCount == 0 ? false : true);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
-#endif
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestSidAttribute(TestUser user)
+        {
+            string searchInput = user.SID;
+            string claimValue = user.SID;
+            string claimType = base.UserIdentifierClaimType;
+            base.TestSearchOperation(searchInput, 1, claimValue);
+            base.TestValidationOperation(claimType, claimValue, true);
+        }
     }
 
     [TestFixture]
@@ -63,9 +69,38 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestSidAttribute(TestUser user)
+        {
+            string searchInput = user.SID;
+            string claimValue = user.UserPrincipalName;
+            string claimType = base.UserIdentifierClaimType;
+            base.TestSearchOperation(searchInput, 1, claimValue);
+            base.TestValidationOperation(claimType, claimValue, true);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
+        {
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
+
 #if DEBUG
-        [TestCase(UnitTestsHelper.ValidUserSid, 1, @"testLdapcpseUser_001@contoso.local")]
-        [TestCase(@"testLdapcpseUser_001", 1, @"testLdapcpseUser_001@contoso.local")]
+        [TestCase(@"testLdapcpUser_001", 1, @"testLdapcpUser_001@contoso.local")]
         public void TestSidAttribute(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
         {
             base.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);
@@ -74,6 +109,7 @@ namespace Yvand.LdapClaimsProvider.Tests
 #endif
     }
 
+#if DEBUG
     [TestFixture]
     [Parallelizable(ParallelScope.Children)]
     public class UseSidAttributeForUserPermissionTests : ClaimsProviderTestsBase
@@ -101,16 +137,37 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-#if DEBUG
-        [TestCase(UnitTestsHelper.ValidUserSid, 1, UnitTestsHelper.ValidUserSid)]
-        [TestCase(@"S-1-5-21-0000000000-1611586658-188888215-107206", 0, @"")]
-        public void TestSidAttribute(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestSidAttribute(TestUser user)
         {
-            base.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);
-            base.TestValidationOperation(TestContext.Parameters["MultiPurposeCustomClaimType"], inputValue, expectedResultCount == 0 ? false : true);
+            string searchInput = user.SID;
+            string claimValue = user.SID;
+            string claimType = TestContext.Parameters["MultiPurposeCustomClaimType"];
+            base.TestSearchOperation(searchInput, 1, claimValue);
+            base.TestValidationOperation(claimType, claimValue, true);
         }
-#endif
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
+        {
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
+        }
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
     }
+#endif
 
     [TestFixture]
     [Parallelizable(ParallelScope.Children)]
@@ -140,21 +197,34 @@ namespace Yvand.LdapClaimsProvider.Tests
             base.CheckSettingsTest();
         }
 
-#if DEBUG
-        [TestCase(UnitTestsHelper.ValidGroupSid, 1, UnitTestsHelper.ValidGroupSid)]
-        [TestCase("group1", 1, UnitTestsHelper.ValidGroupSid)]
-        public void TestGroupSidAttribute(string inputValue, int expectedResultCount, string expectedEntityClaimValue)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestSidAttribute(TestGroup group)
         {
-            base.TestSearchOperation(inputValue, expectedResultCount, expectedEntityClaimValue);
-            base.TestValidationOperation(base.GroupIdentifierClaimType, expectedEntityClaimValue, expectedResultCount == 0 ? false : true);
+            string searchInput = group.SamAccountName;
+            string claimValue = group.SID;
+            string claimType = base.Settings.ClaimTypes.GroupIdentifierConfig.ClaimType;
+            base.TestSearchOperation(searchInput, 1, claimValue);
+            base.TestValidationOperation(claimType, claimValue, true);
         }
 
-        [TestCase("FakeAccount", false)]
-        [TestCase("yvand@contoso.local", true)]
-        public void TestAugmentationOperation(string claimValue, bool isMemberOfTrustedGroup)
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeUsers), new object[] { TestEntitySourceManager.MaxNumberOfUsersToTest })]
+        public void TestUsers(TestUser user)
         {
-            base.TestAugmentationOperation(claimValue, isMemberOfTrustedGroup, UnitTestsHelper.ValidGroupSid);
+            base.TestSearchAndValidateForTestUser(user);
+            base.TestAugmentationAgainst1RandomGroup(user);
         }
-#endif
+
+        [Test, TestCaseSource(typeof(TestEntitySourceManager), nameof(TestEntitySourceManager.GetSomeGroups), new object[] { TestEntitySourceManager.MaxNumberOfGroupsToTest })]
+        public void TestGroups(TestGroup group)
+        {
+            TestSearchAndValidateForTestGroup(group);
+        }
+
+        [Test]
+        [Repeat(5)]
+        public override void TestAugmentationOfGoldUsersAgainstRandomGroups()
+        {
+            base.TestAugmentationOfGoldUsersAgainstRandomGroups();
+        }
     }
 }

--- a/Yvand.LDAPCPSE.Tests/Yvand.LDAPCPSE.Tests.csproj
+++ b/Yvand.LDAPCPSE.Tests/Yvand.LDAPCPSE.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{90A764E3-68F7-4E55-B557-E46B98340216}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -15,23 +15,23 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DebugType>full</DebugType>
     <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.SharePoint, Version=16.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
@@ -72,14 +72,15 @@
       <Version>13.0.3</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
-      <Version>4.0.1</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter">
-      <Version>4.5.0</Version>
+      <Version>4.6.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="local.runsettings" />
+    <None Include="Setup\Populate-ActiveDirectory.ps1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Yvand.LDAPCPSE.Tests/local.runsettings
+++ b/Yvand.LDAPCPSE.Tests/local.runsettings
@@ -5,19 +5,14 @@
   </RunConfiguration>
   <TestRunParameters>
     <Parameter name="ClaimsProviderName" value="LDAPCPSE" />
-    <Parameter name="ClaimsProviderConfigName" value="LDAPCSEPConfig" />
-    <Parameter name="LdapConnections" value="C:\YvanData\Dev\LDAPCP_CustomLDAPConnections.json" />
+    <Parameter name="LdapConnectionsJsonFile" value="C:\YvanData\Dev\LDAPCP_CustomLDAPConnections.json" />
     <Parameter name="DomainFqdn" value="contoso.local" />
-    <Parameter name="Domain" value="contoso" />
     <Parameter name="DataFile_AllAccounts_Search" value="C:\YvanData\Dev\LDAPCP_Tests_AllAccounts_Search.csv" />
     <Parameter name="DataFile_AllAccounts_Validate" value="C:\YvanData\Dev\LDAPCP_Tests_AllAccounts_Validate.csv" />
+    <Parameter name="DataFile_TestUsers" value="C:\YvanData\dev\LDAPCP_Tests_Users.csv" />
+    <Parameter name="DataFile_TestGroups" value="C:\YvanData\dev\LDAPCP_Tests_Groups.csv" />
     <Parameter name="FarmAdmin" value="i:0#.w|contoso\yvand" />
-    <Parameter name="ValidGroupClaimType" value="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" />
-    <Parameter name="ValidGroupName" value="contoso.local\testLdapcpseGroup_1" />
-    <Parameter name="ValidGroupSid" value="S-1-5-21-2647467245-1611586658-188888215-11601" />
-    <Parameter name="ValidUserSid" value="S-1-5-21-2647467245-1611586658-188888215-107206" />
+    <Parameter name="GroupsClaimType" value="http://schemas.microsoft.com/ws/2008/06/identity/claims/role" />
     <Parameter name="MultiPurposeCustomClaimType" value="http://schemas.yvand.org/claims/type1" />
-    <Parameter name="TestSiteCollectionName" value="LDAPCPSE.UnitTests" />
-    <Parameter name="TestLogFileName" value="LDAPCPSEIntegrationTests.log" />
   </TestRunParameters>
 </RunSettings>

--- a/Yvand.LDAPCPSE.sln
+++ b/Yvand.LDAPCPSE.sln
@@ -9,20 +9,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yvand.LDAPCPSE.Tests", "Yva
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{90A764E3-68F7-4E55-B557-E46B98340216}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{90A764E3-68F7-4E55-B557-E46B98340216}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{90A764E3-68F7-4E55-B557-E46B98340216}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{90A764E3-68F7-4E55-B557-E46B98340216}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Debug|x64.ActiveCfg = Debug|x64
+		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Debug|x64.Build.0 = Debug|x64
+		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Release|x64.ActiveCfg = Release|x64
+		{66F4B88D-7D7E-4435-92DE-94810E2B8F9F}.Release|x64.Build.0 = Release|x64
+		{90A764E3-68F7-4E55-B557-E46B98340216}.Debug|x64.ActiveCfg = Debug|x64
+		{90A764E3-68F7-4E55-B557-E46B98340216}.Debug|x64.Build.0 = Debug|x64
+		{90A764E3-68F7-4E55-B557-E46B98340216}.Release|x64.ActiveCfg = Release|x64
+		{90A764E3-68F7-4E55-B557-E46B98340216}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Yvand.LDAPCPSE/Yvand.LDAPCPSE.csproj
+++ b/Yvand.LDAPCPSE/Yvand.LDAPCPSE.csproj
@@ -31,31 +31,31 @@
     <!-- <DebugType>embedded</DebugType> -->
   </PropertyGroup>
   <!-- Debug configuration -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugType>embedded</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
   <!-- Release configuration -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>embedded</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>8.0</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>portable</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <LangVersion>8.0</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimTypeConfig.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimTypeConfig.cs
@@ -685,6 +685,12 @@ namespace Yvand.LdapClaimsProvider.Configuration
             return ctConfig;
         }
 
+        public IEnumerable<ClaimTypeConfig> GetConfigsMappedToClaimType()
+        {
+            return innerCol.Where(x =>
+                !String.IsNullOrWhiteSpace(x.ClaimType));
+        }
+
         /// <summary>
         /// Returns all configuration objects, excluding the identifier configuration, corresponding to the given <paramref name="entityType"/>
         /// </summary>

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -132,18 +132,18 @@ namespace Yvand.LdapClaimsProvider.Configuration
                         DirectoryObjectAdditionalFilter = "(!(objectClass=computer))",
                         SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("sAMAccountName") ? EntityMetadataPerLdapAttributes["sAMAccountName"] : String.Empty,
                     }
-                }
-                //{
-                //    WIF4_5.ClaimTypes.PrimarySid,
-                //    new ClaimTypeConfig
-                //    {
-                //        DirectoryObjectType = DirectoryObjectType.User,
-                //        DirectoryObjectClass = "user",
-                //        DirectoryObjectAttribute = "objectsid",
-                //        DirectoryObjectAttributeSupportsWildcard = false,
-                //        SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("objectsid") ? EntityMetadataPerLdapAttributes["objectsid"] : String.Empty,
-                //    }
-                //},
+                },
+                {   // https://github.com/Yvand/LDAPCP/issues/221: Automatically configure user SID
+                    WIF4_5.ClaimTypes.PrimarySid,
+                    new ClaimTypeConfig
+                    {
+                        DirectoryObjectType = DirectoryObjectType.User,
+                        DirectoryObjectClass = "user",
+                        DirectoryObjectAttribute = "objectsid",
+                        DirectoryObjectAttributeSupportsWildcard = false,
+                        SPEntityDataKey = EntityMetadataPerLdapAttributes.ContainsKey("objectsid") ? EntityMetadataPerLdapAttributes["objectsid"] : String.Empty,
+                    }
+                },
             };
             // Returns a copy of the Dictionary, not the Dictionary itself, to prevent its members to be modified
             return defaultSettingsPerUserClaimType.ToList();


### PR DESCRIPTION
## LDAPCP Second Edition v19.0

* Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221
* Improve tests, to make them much easier to replay from a new test environment, and with many more users and groups
