### PR TITLE
Fix validation issue when multiple LDAP connections return an identical entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for LDAPCP
 
+## LDAPCP Second Edition v20.0 - Unreleased
+
+* Fix validation issue when multiple LDAP connections return an identical entity
+
 ## LDAPCP Second Edition v19.0.20240823.4 - Published in August 23, 2024
 
 * Fix error when creating the configuration if the trust uses an identifier claim type that is not well-known by LDAPCP - https://github.com/Yvand/LDAPCP/issues/221

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
@@ -633,7 +633,8 @@ namespace Yvand.LdapClaimsProvider
                     else
                     {
                         SearchOrValidateInLdap();
-                        if (ldapSearchResults?.Count == 1)
+                        // Even if >1 it must proceed, becausee multiple LDAP servers may validate the entity, and ProcessLdapResults() will eliminate duplicates
+                        if (ldapSearchResults?.Count >= 1)
                         {
                             pickerEntityList = this.ProcessLdapResults(currentContext, ldapSearchResults);
                         }


### PR DESCRIPTION
## CHANGELOG

* Fix validation issue when multiple LDAP connections return an identical entity
