### PR TITLE
fix httpcontext for anonymous user 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for LDAPCP
 
+## Unreleased
+
+* Fix again the exception thrown if the claims provider is used in the context of an anonymous user
+
 ## LDAPCP Second Edition v21.0 - Published in February 18, 2025
 
 * Update the ldap authentication mapping to allow the use of Encryption / SecureSocketLayer with SimpleBind when getting group membership - https://github.com/Yvand/LDAPCP/pull/234

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/Configuration/ClaimsProviderConstants.cs
@@ -351,7 +351,7 @@ namespace Yvand.LdapClaimsProvider.Configuration
             if (httpctx != null)
             {
                 WIF4_5.ClaimsPrincipal cp = httpctx.User as WIF4_5.ClaimsPrincipal;
-                if (cp != null && cp.Identity != null)
+                if (cp != null && cp.Identity != null && !String.IsNullOrWhiteSpace(cp.Identity.Name))
                 {
                     if (SPClaimProviderManager.IsEncodedClaim(cp.Identity.Name))
                     {


### PR DESCRIPTION
## CHANGELOG

* Fix again the exception thrown if the claims provider is used in the context of an anonymous user
