### PR TITLE
Fix validation with multiple domains, and a dynamic token is set on the claim type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Fix again the exception thrown if the claims provider is used in the context of an anonymous user
 * Update GitHub workflows
-* Fix validation with multiple domains, and a dynamic token is set on the claim type
+* Fix validation with multiple domains, and a dynamic token is set on the claim type - https://github.com/Yvand/LDAPCP/issues/249
 
 ## LDAPCP Second Edition v21.0 - Published in February 18, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix again the exception thrown if the claims provider is used in the context of an anonymous user
 * Update GitHub workflows
+* Fix validation with multiple domains, and a dynamic token is set on the claim type
 
 ## LDAPCP Second Edition v21.0 - Published in February 18, 2025
 

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
@@ -792,10 +792,11 @@ namespace Yvand.LdapClaimsProvider
 
                     ClaimsProviderEntity uniqueLdapResult = new ClaimsProviderEntity(ldapResult, ctConfig, directoryObjectPropertyValue, permissionClaimValue);
                     PickerEntity pe = CreatePickerEntityHelper(currentContext, uniqueLdapResult);
-                    // This ultimate check during validation is necessary when a token domain is present, since the token value is removed in currentContext.Input, and restored only in pe.Claim.Value
-                    // It prevents adding 1+ results in validation, with same LDAP value but a different domain
-                    if (currentContext.OperationType == OperationType.Validation &&
-                        dynamicDomainTokenSet &&
+                    if (
+                        // https://github.com/Yvand/LDAPCP/issues/249
+                        // If it is a validation and a token domain is present
+                        currentContext.OperationType == OperationType.Validation && dynamicDomainTokenSet &&
+                        // Then the claim's value must be equal to the actual IncomingEntity (cannot compare against currentContext.Input since the domain token is removed for validations)
                         !String.Equals(pe.Claim.Value, currentContext.IncomingEntity.Value, StringComparison.InvariantCultureIgnoreCase))
                     {
                         continue;

--- a/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
+++ b/Yvand.LDAPCPSE/Yvand.LdapClaimsProvider/LDAPCPSE.cs
@@ -791,7 +791,16 @@ namespace Yvand.LdapClaimsProvider
                     }
 
                     ClaimsProviderEntity uniqueLdapResult = new ClaimsProviderEntity(ldapResult, ctConfig, directoryObjectPropertyValue, permissionClaimValue);
-                    spEntities.Add(CreatePickerEntityHelper(currentContext, uniqueLdapResult));
+                    PickerEntity pe = CreatePickerEntityHelper(currentContext, uniqueLdapResult);
+                    // This ultimate check during validation is necessary when a token domain is present, since the token value is removed in currentContext.Input, and restored only in pe.Claim.Value
+                    // It prevents adding 1+ results in validation, with same LDAP value but a different domain
+                    if (currentContext.OperationType == OperationType.Validation &&
+                        dynamicDomainTokenSet &&
+                        !String.Equals(pe.Claim.Value, currentContext.IncomingEntity.Value, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        continue;
+                    }
+                    spEntities.Add(pe);
                     uniqueDirectoryResults.Add(uniqueLdapResult);
                 }
             }


### PR DESCRIPTION
## CHANGELOG

* Fix validation with multiple domains, and a dynamic token is set on the claim type